### PR TITLE
Fix canonical URL on index page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -160,7 +160,7 @@ const galleryItems = ref([
   // }
 ])
 useHead(() => {
-  const canonical = `https://twoja-kolorowanka.pl'}`
+  const canonical = 'https://twoja-kolorowanka.pl'
   const image = `https://twoja-kolorowanka.pl/logo-1.webp`
 
   return {


### PR DESCRIPTION
## Summary
- fix canonical constant on index page

## Testing
- `pnpm build` *(fails: nuxt not found and missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_686405eb2234832ca9e03209d17af033