### PR TITLE
Fix hydration mismatch by removing invalid <p> markup

### DIFF
--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -329,34 +329,34 @@ const openPreviewModal = () => { if (doc.value?.image) showPreviewModal.value = 
         </div>
         <div>
           <Heading v-if="doc?.seoBlocks" :text="doc?.seoBlocks[2]?.heading || ''" :as="'h2'" :backgroundColor="'bg-sec-500'" fontSize="text-3xl" />
-               <p v-html="doc.seoBlocks[2].text || 'Wybierz kategorię, aby zobaczyć dostępne kolorowanki.'" v-if="doc?.seoBlocks" class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
-          </p>
+               <div v-html="doc.seoBlocks[2].text || 'Wybierz kategorię, aby zobaczyć dostępne kolorowanki.'" v-if="doc?.seoBlocks" class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
+          </div>
           <VariantsGallery :items="galleryVariants.slice(8,16)" />
         </div>
           <div>
           <Heading v-if="doc?.seoBlocks" :text="doc?.seoBlocks[3]?.heading || ''" :as="'h2'" :backgroundColor="'bg-sec-500'" fontSize="text-3xl" />
-               <p v-if="doc?.seoBlocks" 
+               <div v-if="doc?.seoBlocks"
                v-html="doc.seoBlocks[3].text ||''"
                class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
-          </p>
+          </div>
           <VariantsGallery :items="galleryVariants.slice(16,24)" />
         </div>
                 <div>
           <Heading v-if="doc?.seoBlocks" :text="doc?.seoBlocks[4]?.heading || ''" :as="'h2'" :backgroundColor="'bg-sec-500'" fontSize="text-3xl" />
-               <p v-html="doc.seoBlocks[4].text ||''" v-if="doc?.seoBlocks" class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
-          </p>
+               <div v-html="doc.seoBlocks[4].text ||''" v-if="doc?.seoBlocks" class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
+          </div>
           <VariantsGallery :items="galleryVariants.slice(24,32)" />
         </div>
         <div>
           <Heading v-if="doc?.seoBlocks" :text="doc?.seoBlocks[5]?.heading || ''" :as="'h2'" :backgroundColor="'bg-sec-500'" fontSize="text-3xl" />
-               <p v-html="doc.seoBlocks[5].text || ''" v-if="doc?.seoBlocks" class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
-          </p>
+               <div v-html="doc.seoBlocks[5].text || ''" v-if="doc?.seoBlocks" class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
+          </div>
           <VariantsGallery :items="galleryVariants.slice(32,40)" />
         </div>
           <div>
           <Heading v-if="doc?.seoBlocks" :text="doc?.seoBlocks[6]?.heading || ''" :as="'h2'" :backgroundColor="'bg-sec-500'" fontSize="text-3xl" />
-               <p v-html="doc.seoBlocks[6].text ||''" v-if="doc?.seoBlocks" class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
-          </p>
+               <div v-html="doc.seoBlocks[6].text ||''" v-if="doc?.seoBlocks" class="mb-12 text-xl font-light text-center mx-auto px-4 lg:px-8">
+          </div>
           <VariantsGallery :items="galleryVariants.slice(40,48)" />
           <ClientOnly>
             <VariantsGallery :items="visibleGalleryVariants"  class="mt-6"/>


### PR DESCRIPTION
## Summary
- ensure SEO block HTML uses `<div>` wrapper instead of `<p>` to avoid invalid nested markup

## Testing
- `npm run build` *(fails: `nuxt: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864121a0644832ca8d127a1c0f84ed3