### PR TITLE
Polityka prywatnosci i RODO: Cloudflare Web Analytics + klauzula transferu poza EOG

### DIFF
--- a/pages/obowiazek-informacyjny.vue
+++ b/pages/obowiazek-informacyjny.vue
@@ -131,11 +131,17 @@
             <li><span>Firmy, za pośrednictwem których świadczone mogą być usługi SEO/SEM</span></li>
             <li><span>Firmy serwisowe i wsparcia IT dokonujące konserwacji lub odpowiedzialne za utrzymanie
                     infrastruktury IT</span></li>
+            <li><span>Firmy dostarczające narzędzia statystyczne dla Serwisu (pomiar odwiedzin bez plików cookies
+                    i bez identyfikatorów Użytkownika)</span></li>
         </ul>
         <h2 class="text-4xl py-4"><span>Czy Państwa dane osobowe będą przekazywane poza Unię Europejską?</span></h2>
-        <p class="text-lg">Dane osobowe<b>nie będą przekazywane poza Unię Europejską</b>, chyba że zostały opublikowane
-            na skutek indywidualnego działania Użytkownika (np. wprowadzenie komentarza lub wpisu), co sprawi, że dane
-            będą dostępne dla każdej osoby odwiedzającej serwis.</p>
+        <p class="text-lg">Dane osobowe co do zasady <b>nie będą przekazywane poza Europejski Obszar Gospodarczy</b>.
+            Jeżeli w związku z korzystaniem przez Administratora z usług dostawców technicznych (np. hosting,
+            statystyki odwiedzin) dochodzi do przekazania danych do państwa trzeciego, odbywa się ono wyłącznie na
+            podstawie zabezpieczeń przewidzianych w RODO – decyzji Komisji Europejskiej stwierdzającej odpowiedni
+            stopień ochrony (w tym ram EU-US Data Privacy Framework) lub standardowych klauzul umownych. Dane
+            opublikowane na skutek indywidualnego działania Użytkownika (np. wprowadzenie komentarza lub wpisu) będą
+            dostępne dla każdej osoby odwiedzającej Serwis.</p>
         <h2 class="text-4xl py-4"><span>Czy dane osobowe będą podstawą zautomatyzowanego podejmowania decyzji?</span>
         </h2>
         <p class="text-lg">Dane osobowe <b>nie będą wykorzystywane</b> do zautomatyzowanego podejmowania decyzji

--- a/pages/polityka-prywatnosci.vue
+++ b/pages/polityka-prywatnosci.vue
@@ -224,6 +224,12 @@
             <li><b>Prowadzenie statystyk:</b>
                 <ul style="list-style: lower-alpha;" class="text-lg py-2 pl-16">
                     <li>Google Tag Manager (policies.google.com/privacy?hl=pl)</li>
+                    <li>Cloudflare Web Analytics (cloudflare.com/privacypolicy) – pomiar odwiedzin <b>bez plików
+                        cookies</b>: skrypt nie zapisuje żadnych danych na Urządzeniu Użytkownika, nie wykorzystuje
+                        identyfikatorów Użytkownika i nie śledzi Użytkowników między witrynami; gromadzi wyłącznie
+                        zbiorcze, anonimowe statystyki odwiedzin (m.in. liczba odsłon, kraj, typ przeglądarki).
+                        Podstawą przetwarzania jest prawnie uzasadniony interes Administratora
+                        (art. 6 ust. 1 lit. f RODO).</li>
                 </ul>
             </li>
             <li><b>Usługi komentarzy:</b>


### PR DESCRIPTION
Strony prawne - do akceptacji Jakuba przed merge.

- **Polityka prywatnosci (par. 7, statystyki):** wpis o Cloudflare Web Analytics - pomiar bez cookies, bez identyfikatorow, podstawa: prawnie uzasadniony interes (art. 6 ust. 1 lit. f RODO)
- **Obowiazek informacyjny:** dodani dostawcy narzedzi statystycznych wsrod podmiotow powierzenia
- **Obowiazek informacyjny:** urealniona klauzula o przekazywaniu danych poza EOG (DPF / standardowe klauzule umowne) - dotychczasowe kategoryczne *nie beda przekazywane poza UE* bylo nieprawdziwe juz przy hostingu na Netlify (USA), GTM i Disqus

🤖 Generated with [Claude Code](https://claude.com/claude-code)