### PR TITLE
9 przekrojow wiekowych (2-7 lat, dziewczynki 8-12) + filtr motyw x trudnosc

### DIFF
--- a/content/kolorowanki/kolorowanki-dla-2-latka/index.md
+++ b/content/kolorowanki/kolorowanki-dla-2-latka/index.md
@@ -1,0 +1,31 @@
+---
+title:          "Kolorowanki dla 2-latka – najprostsze wzory do druku PDF"
+description:    "Kolorowanki dla 2-latka: największe pola, najgrubsze kontury, pojedyncze kształty. Pierwsze kredki bez frustracji. Darmowe PDF do druku A4."
+categoryName:   "Kolorowanki dla 2-latka"
+canonical:      "/kolorowanki/kolorowanki-dla-2-latka/"
+tags:           [ kolorowanki, dla-2-latka, maluchy, pdf ]
+tagsFilter:     [ trudnosc-1 ]
+alt: 'kolorowanki dla 2-latka'
+h1First: Kolorowanki
+h1Sec:  dla 2-latka
+heroImg1: "/serce/1/serce-1.svg"
+heroImg2: "/jedzenie/jablka/1/jablka-1.svg"
+image:          "/serce/1/serce-1.svg"
+keywords:       "kolorowanki dla 2 latka, kolorowanki dla dwulatka, pierwsze kolorowanki"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Czy dwulatek jest gotowy na kolorowanki?"
+    answer: "Tak – pod warunkiem, że wzór jest bardzo prosty. Na tym etapie chodzi o radość z zostawiania śladu kredki i pierwsze próby celowania w kontur, nie o dokładność."
+
+  - question: "Jakie kredki dla dwulatka?"
+    answer: "Grube kredki świecowe albo tzw. kredki-kamyki – mieszczą się w całej dłoni i nie łamią się przy mocnym docisku."
+---
+## Kolorowanki dla 2-latka – najprostsze z prostych
+W tym zestawie są wyłącznie rysunki z najniższego poziomu trudności w całym serwisie: pojedyncze kształty, grube linie, wielkie pola. Dwulatek nie musi się w nic wstrzelić – wystarczy, że macha kredką z radością, a obrazek i tak będzie wyglądał na pokolorowany.
+
+## Na tym etapie liczy się ślad, nie precyzja
+Dwulatek dopiero odkrywa, że jego ruch zostawia kolor na papierze. To wielka rzecz! Nie poprawiaj, nie pokazuj „jak trzeba" – po prostu podawaj kartki i chwal każdy bazgroł. Precyzja przyjdzie za rok, dziś budujemy skojarzenie: kredki = frajda.
+
+## Drukuj bez limitu
+Każdy wzór to darmowy PDF pod kartkę A4. Dwulatek potrafi „skończyć" pracę w dwie minuty, więc śmiało drukuj po kilka sztuk na raz.

--- a/content/kolorowanki/kolorowanki-dla-3-latka/index.md
+++ b/content/kolorowanki/kolorowanki-dla-3-latka/index.md
@@ -4,7 +4,7 @@ description:    "Kolorowanki dla 3-latka: duże kontury, znajome kształty i zer
 categoryName:   "Kolorowanki dla 3-latka"
 canonical:      "/kolorowanki/kolorowanki-dla-3-latka/"
 tags:           [ kolorowanki, dla-3-latka, maluchy, pdf ]
-tagsFilter:     [ trudnosc-1 ]
+tagsFilter:     [ trudnosc-1, trudnosc-2 ]
 alt: 'kolorowanki dla 3-latka'
 h1First: Kolorowanki
 h1Sec:  dla 3-latka

--- a/content/kolorowanki/kolorowanki-dla-4-latka/index.md
+++ b/content/kolorowanki/kolorowanki-dla-4-latka/index.md
@@ -1,0 +1,31 @@
+---
+title:          "Kolorowanki dla 4-latka – wzory do druku PDF"
+description:    "Kolorowanki dla 4-latka: trochę więcej detali niż dla maluchów, wciąż czytelne kontury. Dobrane po realnym poziomie trudności. Darmowe PDF do druku A4."
+categoryName:   "Kolorowanki dla 4-latka"
+canonical:      "/kolorowanki/kolorowanki-dla-4-latka/"
+tags:           [ kolorowanki, dla-4-latka, przedszkolak, pdf ]
+tagsFilter:     [ trudnosc-2, trudnosc-3 ]
+alt: 'kolorowanki dla 4-latka'
+h1First: Kolorowanki
+h1Sec:  dla 4-latka
+heroImg1: "/kroliczki/1/kroliczki-1.svg"
+heroImg2: "/zwierzeta/zabki/1/zabki-1.svg"
+image:          "/kroliczki/1/kroliczki-1.svg"
+keywords:       "kolorowanki dla 4 latka, kolorowanki dla czterolatka, kolorowanki dla przedszkolaka"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Co wyróżnia kolorowanki dla czterolatka?"
+    answer: "Wzory mają już 2–3 elementy i pierwsze drobniejsze pola, ale kontury pozostają wyraźne. Czterolatek mieści się w liniach coraz pewniej i zaczyna świadomie dobierać kolory."
+
+  - question: "Jak dobieracie trudność rysunków?"
+    answer: "Każda kolorowanka w serwisie ma zmierzony obiektywny poziom złożoności (od 1 do 10) na podstawie liczby detali w rysunku. Do tego zestawu trafiają poziomy 2–3 – w sam raz na czteroletnie rączki."
+---
+## Kolorowanki dla 4-latka – krok dalej niż maluch
+Czterolatek już wie, że trawa bywa zielona, a słońce żółte – i chce to pokazać. Zebrane tu rysunki mają odrobinę więcej szczegółów niż wzory dla maluchów, ale wciąż na tyle czytelne kontury, żeby praca kończyła się sukcesem, a nie zniechęceniem.
+
+## Dobrane po zmierzonej trudności, nie na oko
+Każdy rysunek w naszym serwisie ma obliczony poziom złożoności od 1 do 10. Do tego zestawu automatycznie trafiają poziomy 2–3 – dzięki temu masz pewność, że „dla 4-latka" naprawdę znaczy dla 4-latka, niezależnie od tematu rysunku.
+
+## Darmowe PDF na kartkę A4
+Klikasz, drukujesz, podajesz kredki. Bez rejestracji i bez limitów – także do przedszkola.

--- a/content/kolorowanki/kolorowanki-dla-5-latka/index.md
+++ b/content/kolorowanki/kolorowanki-dla-5-latka/index.md
@@ -4,7 +4,7 @@ description:    "Kolorowanki dla 5-latka: koty, pieski, dinozaury, samochody, je
 categoryName:   "Kolorowanki dla 5-latka"
 canonical:      "/kolorowanki/kolorowanki-dla-5-latka/"
 tags:           [ kolorowanki, dla-5-latka, przedszkolak, pdf ]
-tagsFilter:     [ koty, pieski, dinozaury, samochody, jednorozce, syrenki ]
+tagsFilter:     [ trudnosc-3, trudnosc-4 ]
 alt: 'kolorowanki dla 5-latka'
 h1First: Kolorowanki
 h1Sec:  dla 5-latka

--- a/content/kolorowanki/kolorowanki-dla-6-latka/index.md
+++ b/content/kolorowanki/kolorowanki-dla-6-latka/index.md
@@ -1,0 +1,31 @@
+---
+title:          "Kolorowanki dla 6-latka – wzory do druku PDF"
+description:    "Kolorowanki dla 6-latka: średni poziom detali dla sprawnych rączek zerówkowicza. Dobrane po realnym poziomie trudności. Darmowe PDF do druku A4."
+categoryName:   "Kolorowanki dla 6-latka"
+canonical:      "/kolorowanki/kolorowanki-dla-6-latka/"
+tags:           [ kolorowanki, dla-6-latka, zerowka, pdf ]
+tagsFilter:     [ trudnosc-4, trudnosc-5 ]
+alt: 'kolorowanki dla 6-latka'
+h1First: Kolorowanki
+h1Sec:  dla 6-latka
+heroImg1: "/koty/1/koty-1.svg"
+heroImg2: "/pojazdy/samochody/1/samochody-1.svg"
+image:          "/koty/1/koty-1.svg"
+keywords:       "kolorowanki dla 6 latka, kolorowanki dla sześciolatka, kolorowanki zerówka"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Jaki poziom trudności jest dobry dla sześciolatka?"
+    answer: "Zerówkowicz pewnie operuje kredką i lubi rysunki, w których jest co robić: kilka planów, drobniejsze pola, elementy tła. W naszej 10-stopniowej skali złożoności to poziomy 4–5 – i dokładnie takie wzory zbiera ten zestaw."
+
+  - question: "Czy kolorowanie pomaga w nauce pisania?"
+    answer: "Bardzo – to trening tych samych mięśni dłoni i tej samej kontroli ruchu, które za chwilę posłużą do stawiania liter w zeszycie."
+---
+## Kolorowanki dla 6-latka – w sam raz przed pierwszą klasą
+Sześciolatek to już mistrz kredki: potrafi zaplanować pracę, cieniować i dbać o szczegóły. Ten zestaw automatycznie zbiera rysunki ze środkowych poziomów naszej skali trudności (4–5 na 10) – wystarczająco bogate, by wciągnąć na pół godziny, wciąż na tyle przyjazne, by nie zniechęcić.
+
+## Pomost między zabawą a szkołą
+W zerówce kolorowanie pracuje na konkretny cel: dłoń nabiera siły i precyzji przed nauką pisania, a doprowadzanie rysunku do końca ćwiczy wytrwałość. Daj dziecku wybór wzoru i nie przerywaj, gdy pracuje – skupienie to mięsień, który właśnie rośnie.
+
+## Darmowe PDF do druku
+Wszystkie wzory w formacie A4, bez rejestracji. Wydrukuj kilka na zapas – szkolne popołudnia lubią mieć plan B.

--- a/content/kolorowanki/kolorowanki-dla-7-latka/index.md
+++ b/content/kolorowanki/kolorowanki-dla-7-latka/index.md
@@ -1,0 +1,31 @@
+---
+title:          "Kolorowanki dla 7-latka – wzory do druku PDF"
+description:    "Kolorowanki dla 7-latka: bogatsze detale dla ucznia pierwszej klasy. Dobrane po realnym poziomie trudności. Darmowe PDF do druku A4."
+categoryName:   "Kolorowanki dla 7-latka"
+canonical:      "/kolorowanki/kolorowanki-dla-7-latka/"
+tags:           [ kolorowanki, dla-7-latka, pierwszoklasista, pdf ]
+tagsFilter:     [ trudnosc-5, trudnosc-6 ]
+alt: 'kolorowanki dla 7-latka'
+h1First: Kolorowanki
+h1Sec:  dla 7-latka
+heroImg1: "/zwierzeta/dinozaury/1/dinozaury-1.svg"
+heroImg2: "/fantasy/jednorozce/1/jednorozce-1.svg"
+image:          "/zwierzeta/dinozaury/1/dinozaury-1.svg"
+keywords:       "kolorowanki dla 7 latka, kolorowanki dla siedmiolatka, kolorowanki dla pierwszoklasisty"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Czym różnią się kolorowanki dla siedmiolatka od młodszych zestawów?"
+    answer: "Rysunki mają wyraźnie więcej detali: faktury, tła, mniejsze pola wymagające precyzji. W naszej 10-stopniowej skali złożoności to poziomy 5–6 – wyzwanie, które cieszy, a nie męczy."
+
+  - question: "Po co pierwszoklasiście kolorowanki, skoro już pisze?"
+    answer: "Właśnie dlatego – kolorowanie odpręża po dniu pełnym liter i cyfr, a jednocześnie dalej rozwija precyzję ręki. To odpoczynek, który nie jest ekranem."
+---
+## Kolorowanki dla 7-latka – detale dla wprawnego oka
+Pierwszoklasista chce, żeby efekt wyglądał „jak prawdziwy" – i ma już rękę, by to osiągnąć. Zestaw zbiera rysunki z poziomów 5–6 naszej skali trudności: faktury, tła i drobniejsze pola, przy których można pokazać, co się potrafi.
+
+## Odpoczynek od ekranu i zeszytu
+Po szkolnym dniu głowa siedmiolatka potrzebuje zajęcia, które wycisza, ale nie nudzi. Pół godziny z kolorowanką działa jak reset – dłoń pracuje, myśli odpływają, a na końcu zostaje konkretny efekt do powieszenia nad biurkiem.
+
+## Darmowe PDF w formacie A4
+Bez rejestracji, bez limitów – do domu i do świetlicy. Drukuj i koloruj.

--- a/content/kolorowanki/kolorowanki-dla-dziewczyn-od-12-lat/index.md
+++ b/content/kolorowanki/kolorowanki-dla-dziewczyn-od-12-lat/index.md
@@ -1,0 +1,32 @@
+---
+title:          "Kolorowanki dla dziewczyn od 12 lat – do druku PDF"
+description:    "Kolorowanki dla dziewczyn od 12 lat: najbardziej misterne wzory w serwisie – kwiaty, motyle i magiczne motywy na poziomie antystresowym. Darmowe PDF A4."
+categoryName:   "Kolorowanki dla dziewczyn od 12 lat"
+canonical:      "/kolorowanki/kolorowanki-dla-dziewczyn-od-12-lat/"
+tags:           [ kolorowanki, dla-dziewczyn, 12-lat, nastolatki, pdf ]
+tagsFilter:     [ jednorozce, syrenki, ksiezniczki, wrozki, motyle, serce, kwiat, koniki, flamingi, dla-dziewczynek ]
+tagsFilterAnd:  [ trudnosc-9, trudnosc-10 ]
+alt: 'kolorowanki dla dziewczyn od 12 lat'
+h1First: Kolorowanki
+h1Sec:  dla dziewczyn od 12 lat
+heroImg1: "/zwierzeta/motyle/1/motyle-1.svg"
+heroImg2: "/serce/1/serce-1.svg"
+image:          "/zwierzeta/motyle/1/motyle-1.svg"
+keywords:       "kolorowanki dla dziewczyn od 12 lat, kolorowanki dla nastolatek"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Czym różnią się te kolorowanki od wersji dla dorosłych?"
+    answer: "Poziomem trudności – niczym. To najwyższe poziomy (9–10) naszej skali złożoności, czyli pełnoprawne wzory antystresowe. Różnica jest w tematyce: zamiast abstrakcyjnych mandali – motyle, kwiaty i motywy pełne magii."
+
+  - question: "Czy to nie „za dziecinne” dla nastolatki?"
+    answer: "Spójrz na galerię – te wzory wiszą potem w ramkach na ścianach pokoi. Misterny motyl pokolorowany brush penami to dekoracja, nie laurka."
+---
+## Kolorowanki dla dziewczyn od 12 lat – poziom: mistrzowski
+To najbardziej wymagające wzory w całym serwisie (poziomy 9–10 z 10) w dziewczęcych klimatach: koronkowe motyle, ornamentowe serca, kwiatowe kompozycje gęste jak haft. Dokładnie ta sama liga co kolorowanki antystresowe dla dorosłych – tylko tematyka młodsza o kilka uśmiechów.
+
+## Sztuka relaksu bez ekranu
+Badania i praktyka mówią to samo: godzina z misternym wzorem obniża napięcie skuteczniej niż godzina scrollowania. Playlist, cienkopisy, może herbata – i najtrudniejszy sprawdzian tygodnia przestaje istnieć.
+
+## Darmowe PDF do druku A4
+Bez rejestracji. Gotowe prace świetnie wyglądają w ramkach – galeria na ścianie pokoju robi się sama.

--- a/content/kolorowanki/kolorowanki-dla-dziewczynek-10-lat/index.md
+++ b/content/kolorowanki/kolorowanki-dla-dziewczynek-10-lat/index.md
@@ -1,0 +1,32 @@
+---
+title:          "Kolorowanki dla dziewczynek 10 lat – do druku PDF"
+description:    "Kolorowanki dla dziewczynek 10 lat: misterne jednorożce, kwiaty i motyle z ambitnymi detalami. Darmowe PDF do druku A4."
+categoryName:   "Kolorowanki dla dziewczynek 10 lat"
+canonical:      "/kolorowanki/kolorowanki-dla-dziewczynek-10-lat/"
+tags:           [ kolorowanki, dla-dziewczynek, 10-lat, pdf ]
+tagsFilter:     [ jednorozce, syrenki, ksiezniczki, wrozki, motyle, serce, kwiat, koniki, flamingi, dla-dziewczynek ]
+tagsFilterAnd:  [ trudnosc-7, trudnosc-8 ]
+alt: 'kolorowanki dla dziewczynek 10 lat'
+h1First: Kolorowanki
+h1Sec:  dla dziewczynek 10 lat
+heroImg1: "/fantasy/syrenki/1/syrenki-1.svg"
+heroImg2: "/fantasy/jednorozce/1/jednorozce-1.svg"
+image:          "/fantasy/syrenki/1/syrenki-1.svg"
+keywords:       "kolorowanki dla dziewczynek 10 lat, kolorowanki dla dziesięciolatki"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Czy te wzory nie są za trudne?"
+    answer: "Zestaw zbiera poziomy 7–8 z naszej 10-stopniowej skali złożoności – dużo detali, ale wciąż poniżej mandali dla dorosłych. Dziesięciolatka z odrobiną cierpliwości poradzi sobie z każdym wzorem."
+
+  - question: "Ile czasu zajmuje jeden rysunek?"
+    answer: "Zwykle 30–60 minut – to już projekty na całe popołudnie, do których można wracać. Efekt nadaje się do oprawienia w ramkę."
+---
+## Kolorowanki dla dziewczynek 10 lat – projekty, nie obrazki
+W wieku dziesięciu lat kolorowanka przestaje być zabawą na kwadrans, a staje się projektem: misterna syrenka, jednorożec z bogatą grzywą, kompozycja kwiatowa jak z zeszytu botanika. Ten zestaw zbiera dziewczęce motywy z wysokich poziomów trudności (7–8), przy których naprawdę można się wykazać.
+
+## Prawie jak antystresowe – ale wciąż bajkowe
+To pomost między dziecięcym kolorowaniem a wzorami dla dorosłych: detali jest dużo, ale tematyka pozostaje pełna magii. Idealne na spokojne wieczory i deszczowe weekendy.
+
+## Darmowe PDF do druku A4
+Bez rejestracji, bez limitów – drukuj i twórz galerię na ścianę.

--- a/content/kolorowanki/kolorowanki-dla-dziewczynek-11-lat/index.md
+++ b/content/kolorowanki/kolorowanki-dla-dziewczynek-11-lat/index.md
@@ -1,0 +1,32 @@
+---
+title:          "Kolorowanki dla dziewczynek 11 lat – do druku PDF"
+description:    "Kolorowanki dla dziewczynek 11 lat: ambitne wzory z pogranicza antystresowych – kwiaty, motyle, jednorożce pełne detali. Darmowe PDF do druku A4."
+categoryName:   "Kolorowanki dla dziewczynek 11 lat"
+canonical:      "/kolorowanki/kolorowanki-dla-dziewczynek-11-lat/"
+tags:           [ kolorowanki, dla-dziewczynek, 11-lat, pdf ]
+tagsFilter:     [ jednorozce, syrenki, ksiezniczki, wrozki, motyle, serce, kwiat, koniki, flamingi, dla-dziewczynek ]
+tagsFilterAnd:  [ trudnosc-8, trudnosc-9 ]
+alt: 'kolorowanki dla dziewczynek 11 lat'
+h1First: Kolorowanki
+h1Sec:  dla dziewczynek 11 lat
+heroImg1: "/rosliny/kwiat/1/kwiat-1.svg"
+heroImg2: "/zwierzeta/motyle/1/motyle-1.svg"
+image:          "/rosliny/kwiat/1/kwiat-1.svg"
+keywords:       "kolorowanki dla dziewczynek 11 lat, kolorowanki dla jedenastolatki"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Co znajdę w tym zestawie?"
+    answer: "Dziewczęce motywy – kwiaty, motyle, jednorożce, syrenki – na poziomach trudności 8–9 z naszej 10-stopniowej skali. To wzory z pogranicza kolorowanek antystresowych: dużo drobnych pól i misternych faktur."
+
+  - question: "Jakie techniki polecacie?"
+    answer: "Cienkopisy do konturów detali, kredki do cieniowania większych pól, ewentualnie brush peny do teł. W tym wieku miks technik daje najciekawsze efekty."
+---
+## Kolorowanki dla dziewczynek 11 lat – niemal antystresowe
+Jedenastolatka często koloruje lepiej niż niejeden dorosły – i potrzebuje wzorów, które to uszanują. Ten zestaw zbiera dziewczęce motywy z bardzo wysokich poziomów trudności (8–9): misterne kwiaty, motyle o koronkowych skrzydłach, jednorożce pełne ornamentów.
+
+## Kolorowanie jako relaks – serio
+W tym wieku kolorowanie zaczyna działać jak u dorosłych: wycisza po szkole, porządkuje myśli, odkleja od telefonu. Godzina z cienkopisami i dobrą playlistą to najlepszy możliwy „czas dla siebie".
+
+## Darmowe PDF w formacie A4
+Drukuj bez ograniczeń. A gdy ten poziom przestanie wystarczać – piętro wyżej czekają mandale i wzory antystresowe.

--- a/content/kolorowanki/kolorowanki-dla-dziewczynek-8-lat/index.md
+++ b/content/kolorowanki/kolorowanki-dla-dziewczynek-8-lat/index.md
@@ -1,0 +1,32 @@
+---
+title:          "Kolorowanki dla dziewczynek 8 lat – do druku PDF"
+description:    "Kolorowanki dla dziewczynek 8 lat: jednorożce, syrenki, księżniczki, motyle i kwiaty w wersjach na ośmioletnie umiejętności. Darmowe PDF do druku A4."
+categoryName:   "Kolorowanki dla dziewczynek 8 lat"
+canonical:      "/kolorowanki/kolorowanki-dla-dziewczynek-8-lat/"
+tags:           [ kolorowanki, dla-dziewczynek, 8-lat, pdf ]
+tagsFilter:     [ jednorozce, syrenki, ksiezniczki, wrozki, motyle, serce, kwiat, koniki, flamingi, dla-dziewczynek ]
+tagsFilterAnd:  [ trudnosc-5, trudnosc-6 ]
+alt: 'kolorowanki dla dziewczynek 8 lat'
+h1First: Kolorowanki
+h1Sec:  dla dziewczynek 8 lat
+heroImg1: "/fantasy/jednorozce/1/jednorozce-1.svg"
+heroImg2: "/zwierzeta/motyle/1/motyle-1.svg"
+image:          "/fantasy/jednorozce/1/jednorozce-1.svg"
+keywords:       "kolorowanki dla dziewczynek 8 lat, kolorowanki dla ośmiolatki"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Jak dobrane są rysunki w tym zestawie?"
+    answer: "Podwójnie: po tematyce (jednorożce, syrenki, księżniczki, wróżki, motyle, kwiaty) i po zmierzonym poziomie trudności dopasowanym do ośmiolatki. Dzięki temu nie trafi tu ani wzór dla malucha, ani mandala dla dorosłych."
+
+  - question: "Czy chłopiec też może z nich korzystać?"
+    answer: "Jasne – podział jest umowny. Jeśli ośmiolatek kocha jednorożce, ten zestaw jest też dla niego."
+---
+## Kolorowanki dla dziewczynek 8 lat – magia w sam raz na ośmiolatkę
+Jednorożce z rozwianą grzywą, syrenki, motyle i kwiatowe kompozycje – wszystko w wersjach dobranych do umiejętności ośmiolatki: wystarczająco szczegółowych, żeby wciągnąć, i wciąż na tyle przyjaznych, żeby efekt cieszył.
+
+## Podwójne dopasowanie: temat + zmierzona trudność
+Każdy rysunek w serwisie ma obliczony poziom złożoności od 1 do 10. Ten zestaw łączy dziewczęce motywy z poziomami 5–6 – czyli dokładnie tym zakresem, w którym ośmioletnia ręka pracuje z przyjemnością.
+
+## Darmowe PDF do druku A4
+Klikasz, drukujesz, kolorujesz. Bez rejestracji – w domu i na zajęciach.

--- a/content/kolorowanki/kolorowanki-dla-dziewczynek-9-lat/index.md
+++ b/content/kolorowanki/kolorowanki-dla-dziewczynek-9-lat/index.md
@@ -1,0 +1,32 @@
+---
+title:          "Kolorowanki dla dziewczynek 9 lat – do druku PDF"
+description:    "Kolorowanki dla dziewczynek 9 lat: bogatsze jednorożce, wróżki, kwiaty i motyle dla wprawnej ręki. Darmowe PDF do druku A4."
+categoryName:   "Kolorowanki dla dziewczynek 9 lat"
+canonical:      "/kolorowanki/kolorowanki-dla-dziewczynek-9-lat/"
+tags:           [ kolorowanki, dla-dziewczynek, 9-lat, pdf ]
+tagsFilter:     [ jednorozce, syrenki, ksiezniczki, wrozki, motyle, serce, kwiat, koniki, flamingi, dla-dziewczynek ]
+tagsFilterAnd:  [ trudnosc-6, trudnosc-7 ]
+alt: 'kolorowanki dla dziewczynek 9 lat'
+h1First: Kolorowanki
+h1Sec:  dla dziewczynek 9 lat
+heroImg1: "/fantasy/wrozki/1/wrozki-1.svg"
+heroImg2: "/rosliny/kwiat/1/kwiat-1.svg"
+image:          "/fantasy/wrozki/1/wrozki-1.svg"
+keywords:       "kolorowanki dla dziewczynek 9 lat, kolorowanki dla dziewięciolatki"
+robots:         "index, follow"
+schemaType:     "CollectionPage"
+faqs:
+  - question: "Czym ten zestaw różni się od wersji dla ośmiolatek?"
+    answer: "Wyższym progiem trudności (poziomy 6–7 w naszej 10-stopniowej skali): więcej faktur, drobniejsze pola, bardziej złożone kompozycje. Tematyka pozostaje dziewczęca."
+
+  - question: "Kredki czy cienkopisy?"
+    answer: "W tym wieku świetnie sprawdzają się oba – cienkopisy pozwalają dopieścić drobne detale, a kredki dają cieniowanie. Warto mieć jedno i drugie pod ręką."
+---
+## Kolorowanki dla dziewczynek 9 lat – detali coraz więcej
+Dziewięciolatka nie chce „obrazka dla dzieci" – chce rysunek, przy którym można pokazać charakter pisma kredki. Ten zestaw zbiera dziewczęce motywy z poziomów trudności 6–7: wróżki z misternymi skrzydłami, kwiatowe bukiety, jednorożce z detalami grzywy.
+
+## Kolorowanie jako własny styl
+W tym wieku zaczyna się eksperymentowanie: cieniowanie, gradienty, własne palety kolorów. Podpowiedz technikę, ale wybór zostaw – to już jej projekt artystyczny, nie ćwiczenie.
+
+## Darmowe PDF w formacie A4
+Wszystkie wzory bez rejestracji i bez limitu wydruków.

--- a/docs/przekroje-howto.md
+++ b/docs/przekroje-howto.md
@@ -13,6 +13,11 @@
    przez `scripts/tag-difficulty.mjs` na podstawie złożoności SVG — cron miesięczny je uzupełnia
    dla nowych kolorowanek). Przekroje wiekowe/poziomowe filtruj po trudności, tematyczne po kategoriach.
    Ile leafów ma dany tag: `grep -rl "^- koty$" content --include=index.md | grep -E "/[0-9]+/" | wc -l`
+   **Logika I (motyw × trudność):** dodatkowe pole `tagsFilterAnd` — leaf musi mieć dowolny tag
+   z `tagsFilter` ORAZ dowolny z `tagsFilterAnd`. Np. strony „dla dziewczynek X lat":
+   `tagsFilter: [jednorozce, syrenki, ...]` + `tagsFilterAnd: [trudnosc-7, trudnosc-8]`.
+   UWAGA: cudzysłowy typograficzne i dwukropki w polach YAML potrafią wywalić parser —
+   `pnpm health` waliduje teraz YAML całego content/.
 4. **Napisz copy** (patrz szablon niżej): title, description, 4–6 sekcji `##`, 3–4 FAQ.
 5. **Sprawdź**: `pnpm health` (canonical + obrazki), lokalnie `pnpm dev` → `localhost:3000/kolorowanki/<slug>/`.
 6. Commit + PR. Po deployu strona sama trafia do sitemapy i jako kafelek na hub `/kolorowanki/`.
@@ -71,7 +76,11 @@ Zamknięcie z wezwaniem do działania i informacją o darmowych PDF A4.
 - Unikalne copy per przekrój — żadnego kopiowania sekcji między stronami.
 - Zmiana sluga po publikacji = redirect 301 w `netlify.toml`.
 
-## Dotychczasowe przekroje (2026-07-24)
+## Dotychczasowe przekroje (2026-07-24; pełna lista = podkatalogi `content/kolorowanki/`)
+
+Drabinka wiekowa (po trudności): 2 latka → 1; 3 latka → 1–2; 4 latka → 2–3; 5 latka → 3–4;
+6 latka → 4–5; 7 latka → 5–6; dziewczynki 8 lat → motyw×5–6; 9 lat → ×6–7; 10 lat → ×7–8;
+11 lat → ×8–9; od 12 lat → ×9–10.
 
 | URL | tagsFilter |
 |---|---|

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -97,14 +97,23 @@ const fixImageUrl = (imgUrl) => {
   return clean
 }
 
+// Drugi filtr (logika I): leaf musi miec dowolny tag z tagsFilter ORAZ dowolny z tagsFilterAnd.
+// Uzycie: przekroje typu motyw x trudnosc (np. dla dziewczynek 10 lat).
+const tagsFilterAnd = computed(() => {
+  const t = doc.value?.tagsFilterAnd
+  if (Array.isArray(t)) return t.map(String).filter(Boolean)
+  if (typeof t === 'string') return t.split(',').map(s => s.trim()).filter(Boolean)
+  return []
+})
+
 const { data: tagRaw } = await useAsyncData(
   `tag:${currentPath}`,
   () => {
     if (!tagsFilter.value.length || isLeaf.value) return []
     return queryContent()
-      .where({ tags: { $containsAny: tagsFilter.value } }) 
-      .where({ _path: { $regex: '^.+/[0-9]+/?$' } })      
-      .only(['_path','image','title','alt'])
+      .where({ tags: { $containsAny: tagsFilter.value } })
+      .where({ _path: { $regex: '^.+/[0-9]+/?$' } })
+      .only(['_path','image','title','alt','tags'])
       .find()
   },
   {
@@ -113,12 +122,15 @@ const { data: tagRaw } = await useAsyncData(
 )
 
 const galleryByTag = computed(() =>
-  (tagRaw.value || []).sort(byNum).map(v => ({
-    img: fixImageUrl(v.image),
-    url: v._path, 
-    title: v.title, 
-    alt: v.alt || v.title
-  }))
+  (tagRaw.value || [])
+    .filter(v => !tagsFilterAnd.value.length ||
+      (Array.isArray(v.tags) && v.tags.some(t => tagsFilterAnd.value.includes(t))))
+    .sort(byNum).map(v => ({
+      img: fixImageUrl(v.image),
+      url: v._path,
+      title: v.title,
+      alt: v.alt || v.title
+    }))
 )
 /* --- KONIEC bloku tagów --- */
 

--- a/scripts/health-check.mjs
+++ b/scripts/health-check.mjs
@@ -46,9 +46,23 @@ function frontmatter (file) {
 
 const rel = p => p.slice(ROOT.length).replace(/\\/g, '/')
 
+// Pelna walidacja YAML frontmattera - zepsuty frontmatter wywala caly build @nuxt/content
+const YAML = await import('yaml').then(m => m.default).catch(() => null)
+
 for (const file of mdFiles) {
   const fm = frontmatter(file)
   const where = rel(file)
+
+  if (YAML) {
+    const raw = readFileSync(file, 'utf8')
+    const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+    if (m) {
+      try { YAML.parse(m[1]) } catch (e) {
+        errors.push(`${where}: zepsuty YAML we frontmatter - ${e.message.split('\n')[0]}`)
+        continue
+      }
+    }
+  }
 
   // 1. canonical -> istniejaca strona (blog jest z WordPressa, poza content/)
   if (fm.canonical && !fm.canonical.startsWith('/blog')) {


### PR DESCRIPTION
Drabinka wiekowa po zmierzonej trudnosci + nowe pole tagsFilterAnd (logika I) dla stron dziewczecych (motyw ORAZ trudnosc). Testowane na dev: wszystkie 200, strona dziewczynek-10-lat pokazuje wylacznie motywy dziewczece na poziomach 7-8. Health-check waliduje teraz YAML frontmatterow.

?? Generated with [Claude Code](https://claude.com/claude-code)