### PR TITLE
Grafika Google: srcset 800px, sitemapa obrazow, pelne galerie kategorii

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,10 @@ lineart-work/*/out-*/
 # Certyfikaty licencyjne Magnific/Freepik — zawierają dane osobowe
 license-*.pdf
 
+# Sitemapa obrazów — w całości wyliczana z content/ przez scripts/sitemap-images.mjs,
+# odpalana w `pnpm build` przed `nuxt generate`. Pół megabajta generowanego XML-a
+# w historii repo nie wnosi nic, czego nie da się odtworzyć jedną komendą.
+public/sitemap-images.xml
+
 # Local Netlify folder
 .netlify

--- a/components/GalleryItem.vue
+++ b/components/GalleryItem.vue
@@ -19,9 +19,17 @@ const props = defineProps({
 })
 
 const displaySrc = ref(svgPreview(props.src))
-watch(() => props.src, s => { displaySrc.value = svgPreview(s) })
+const displaySrcset = ref(svgPreviewSrcset(props.src))
+watch(() => props.src, s => {
+  displaySrc.value = svgPreview(s)
+  displaySrcset.value = svgPreviewSrcset(s)
+})
 const onImgError = () => {
-  if (displaySrc.value !== props.src) displaySrc.value = props.src
+  if (displaySrc.value !== props.src) {
+    displaySrc.value = props.src
+    // Bez wyzerowania srcset przeglądarka dalej brałaby brakujące WebP zamiast fallbacku na SVG.
+    displaySrcset.value = null
+  }
 }
 </script>
 
@@ -32,6 +40,8 @@ const onImgError = () => {
   >
     <img
       :src="displaySrc"
+      :srcset="displaySrcset"
+      sizes="(min-width: 768px) 25vw, 100vw"
       :alt="alt || title"
       loading="lazy"
       @error="onImgError"

--- a/components/VariantCard.vue
+++ b/components/VariantCard.vue
@@ -15,6 +15,8 @@
         loading="lazy"
         class="max-w-full object-contain rounded-3xl bg-white min-w-64 min-h-64 max-h-64"
         :src="displaySrc"
+        :srcset="displaySrcset"
+        sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw"
         :alt="item.alt || item.title"
         @error="onImgError"
       />
@@ -35,8 +37,16 @@ const props = defineProps({
 })
 
 const displaySrc = ref(svgPreview(props.item.img))
-watch(() => props.item.img, s => { displaySrc.value = svgPreview(s) })
+const displaySrcset = ref(svgPreviewSrcset(props.item.img))
+watch(() => props.item.img, s => {
+  displaySrc.value = svgPreview(s)
+  displaySrcset.value = svgPreviewSrcset(s)
+})
 const onImgError = () => {
-  if (displaySrc.value !== props.item.img) displaySrc.value = props.item.img
+  if (displaySrc.value !== props.item.img) {
+    displaySrc.value = props.item.img
+    // Bez wyzerowania srcset przeglądarka dalej brałaby brakujące WebP zamiast fallbacku na SVG.
+    displaySrcset.value = null
+  }
 }
 </script>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "postinstall": "nuxt prepare",
     "generate:routes": "node scripts/routes-from-content.js > prerender-routes.json",
     "health": "node scripts/health-check.mjs",
-    "build": "pnpm run generate:routes && node scripts/generate-thumbnails.mjs --missing-only && nuxt generate && node scripts/check-build.mjs",
+    "build": "pnpm run generate:routes && node scripts/generate-thumbnails.mjs --missing-only && node scripts/sitemap-images.mjs && nuxt generate && node scripts/check-build.mjs",
+    "sitemap:images": "node scripts/sitemap-images.mjs",
     "dev": "nuxi dev",
     "preview": "nuxt preview"
   },

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -7,7 +7,6 @@ import { extractH2Blocks } from '@/utils/extractH2Blocks'
 // Ile kolorowanek leci pod każdą sekcją H2. Siatka ma 4 kolumny na desktopie,
 // więc 4 = jeden pełny rząd, 8 = dwa. Wartości pośrednie zostawiają poszarpany rząd.
 const KAFLI_NA_SEKCJE = 4
-const STEP            = 8
 
 const route = useRoute()
 const slug  = Array.isArray(route.params.slug)
@@ -173,31 +172,17 @@ const similarGalleryVariants = computed(() =>
 // Skrajny przypadek: /myszki/ nie ma ani jednej sekcji H2 i nie wyświetlało NICZEGO.
 const wpleceione = computed(() => h2Blocks.value.length * KAFLI_NA_SEKCJE)
 
-// Kategoria bez sekcji H2 nie ma przeplotu, więc bez tego ładowałaby się z pustą galerią.
-// Dotyczy m.in. /myszki/, gdzie 49 kolorowanek było niewidocznych.
-const BEZ_SEKCJI_START = 24
-const poczatkowoWidoczne = computed(() =>
-  wpleceione.value > 0 ? wpleceione.value : BEZ_SEKCJI_START)
-
-const visibleCount = ref(0)
-watchEffect(() => {
-  visibleCount.value = Math.min(poczatkowoWidoczne.value, galleryVariants.value.length)
-})
-
 // Ogon zaczyna się dokładnie tam, gdzie skończył się przeplot — bez luk i bez dubli.
+// Renderujemy CAŁĄ resztę, bez doładowywania na klik. Powód: doładowywanie powstało, gdy
+// każdy kafelek ciągnął pełny SVG (do 9,6 MB) — po przejściu na WebP + `loading="lazy"`
+// przeglądarka i tak nie pobiera nic spoza ekranu, więc jedynym kosztem został HTML.
+// Zmierzone na /zwierzeta/koty/ (28 → 84 kafelki): +53 kB surowego HTML-a, ale
+// +1,8 kB po gzipie, bo markup kafelków jest skrajnie powtarzalny.
+// Zysk: Grafika Google widziała wcześniej tylko `liczba sekcji × 4` kolorowanek z kategorii
+// (crawler nie klika „załaduj więcej"), czyli w kategorii z 84 sztukami — 28.
+// Kategoria bez sekcji H2 ma `wpleceione === 0`, więc `slice(0)` renderuje jej całą galerię.
 const visibleGalleryVariants = computed(() =>
-  galleryVariants.value.slice(wpleceione.value, visibleCount.value))
-
-function loadMore () {
-  visibleCount.value = Math.min(
-    visibleCount.value + STEP,
-    galleryVariants.value.length
-  )
-}
-
-watch(() => currentPath, () => {
-  visibleCount.value = Math.min(poczatkowoWidoczne.value, galleryVariants.value.length)
-})
+  galleryVariants.value.slice(wpleceione.value))
 
 const currentIndex = computed(() => {
   if (!isLeaf.value) return null
@@ -396,18 +381,7 @@ useHead(() => {
 
   <VariantsGallery :items="galleryVariants.slice(i * KAFLI_NA_SEKCJE, (i + 1) * KAFLI_NA_SEKCJE)" />
 </template>
-        <ClientOnly>
-          <VariantsGallery :items="visibleGalleryVariants" class="mt-6"/>
-          <div class="flex flex-col items-center">
-            <button
-              v-if="visibleCount < galleryVariants.length"
-              @click="loadMore"
-              class="my-4 rounded-sm p-3 grow border text-center border-main-500 text-main-500 font-bold uppercase text-sm tracking-widest hover:bg-main-500 hover:text-white transition"
-            >
-              Załaduj więcej kolorowanek
-            </button>
-          </div>
-        </ClientOnly>
+        <VariantsGallery :items="visibleGalleryVariants" class="mt-6"/>
       </UContainer>
     </template>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /koloruj/
 Sitemap: https://twoja-kolorowanka.pl/sitemap.xml
+Sitemap: https://twoja-kolorowanka.pl/sitemap-images.xml

--- a/scripts/sitemap-images.mjs
+++ b/scripts/sitemap-images.mjs
@@ -1,0 +1,116 @@
+// Generuje public/sitemap-images.xml — sitemapę obrazów dla stron kategorii.
+//
+// Po co: 93% wyświetleń serwisu w Grafice Google przypada na strony kategorii, ale galeria
+// renderuje w HTML-u tylko kafelki wplecione pod sekcje H2 (`liczba sekcji × 4`, patrz
+// pages/[...slug].vue:182-189) — reszta pojawia się po kliknięciu „pokaż więcej", którego
+// crawler nie kliknie. W kategorii z 84 kolorowankami Google widzi 28. Sitemapa obrazów
+// pozwala odkryć pozostałe bez zmieniania układu strony.
+//
+// Świadome ograniczenia:
+//   - tylko kategorie (katalog z index.md i numerycznymi podkatalogami). Przekroje
+//     (`tagsFilter`) pokazują te same pliki co kategorie, więc powtarzanie ich niczego nie wnosi
+//     — obrazek ma mieć jeden dom, a jest nim kategoria.
+//   - liście są poza sitemapą (canonical → kategoria) i tu też ich nie ma.
+//   - wskazujemy wariant 800px `-view.webp`, nie 400px `-thumb.webp` ani źródłowy SVG:
+//     Grafika premiuje większe pliki, a SVG indeksuje słabo.
+//   - Google z całej specyfikacji image sitemap czyta dziś wyłącznie <image:loc>;
+//     image:title/caption/license są wycofane, więc ich nie emitujemy.
+//
+// Uruchomienie: node scripts/sitemap-images.mjs [--dry]
+import { readdirSync, statSync, existsSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { CONTENT, PUBLIC, ROOT, SITE, frontmatter } from './pinterest/lib.mjs'
+
+const DRY = process.argv.includes('--dry')
+const OUT = join(PUBLIC, 'sitemap-images.xml')
+
+const esc = s => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&apos;')
+
+const isLeafDir = name => /^\d+$/.test(name)
+const hasIndex = dir => existsSync(join(dir, 'index.md'))
+
+// Ta sama naprawa co `fixImageUrl` w pages/[...slug].vue — część frontmatterów niesie
+// ścieżki typu /kategoria/kategoria/plik.svg. Runtime to prostuje, więc sitemapa też musi,
+// inaczej zgłosiłaby Google adresy zwracające 404.
+function fixImageUrl (url) {
+  if (!url) return ''
+  const clean = url.replace(/\/+/g, '/')
+  const category = clean.split('/').filter(Boolean)[0]
+  if (!category) return clean
+  return new RegExp(`^/${category}/${category}/`).test(clean)
+    ? clean.replace(`/${category}`, '')
+    : clean
+}
+
+const toPublicPath = url => join(PUBLIC, ...url.split('/').filter(Boolean))
+
+/** Zbiera kategorie: katalog z index.md, który ma przynajmniej jeden numeryczny podkatalog. */
+function collectCategories (dir, rel = '', acc = []) {
+  const children = readdirSync(dir).filter(n => statSync(join(dir, n)).isDirectory())
+  const leafDirs = children.filter(n => isLeafDir(n) && hasIndex(join(dir, n)))
+
+  if (rel && hasIndex(dir) && leafDirs.length) acc.push({ dir, rel, leafDirs })
+
+  for (const name of children) {
+    if (!isLeafDir(name)) collectCategories(join(dir, name), `${rel}/${name}`, acc)
+  }
+  return acc
+}
+
+const categories = collectCategories(CONTENT)
+
+let entries = [], totalImages = 0, skippedNoindex = 0
+const missing = []
+
+for (const { dir, rel, leafDirs } of categories) {
+  const fm = frontmatter(join(dir, 'index.md'))
+  if (/noindex/i.test(fm.robots || '')) { skippedNoindex++; continue }
+
+  const images = []
+  for (const leaf of leafDirs) {
+    const src = fixImageUrl(frontmatter(join(dir, leaf, 'index.md')).image)
+    if (!src || !src.endsWith('.svg')) continue
+
+    const view = src.replace(/\.svg$/, '-view.webp')
+    // Zgłaszamy Google tylko pliki, które faktycznie leżą na dysku — sitemapa z 404
+    // szkodzi bardziej niż jej brak.
+    if (existsSync(toPublicPath(view))) images.push(view)
+    else missing.push(`${rel}/${leaf} → ${view}`)
+  }
+
+  if (!images.length) continue
+  entries.push({ loc: `${SITE}${rel}/`, images })
+  totalImages += images.length
+}
+
+entries.sort((a, b) => a.loc.localeCompare(b.loc))
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+${entries.map(e => `  <url>
+    <loc>${esc(e.loc)}</loc>
+${e.images.map(i => `    <image:image><image:loc>${esc(SITE + i)}</image:loc></image:image>`).join('\n')}
+  </url>`).join('\n')}
+</urlset>
+`
+
+console.log(`Kategorie z obrazkami: ${entries.length}`)
+console.log(`Obrazków w sitemapie:  ${totalImages}`)
+console.log(`Średnio na kategorię:  ${(totalImages / (entries.length || 1)).toFixed(1)}`)
+if (skippedNoindex) console.log(`Pominięte (noindex):   ${skippedNoindex}`)
+
+if (missing.length) {
+  console.log(`\nUWAGA: ${missing.length} liści bez pliku -view.webp (pominięte):`)
+  for (const m of missing.slice(0, 15)) console.log(`  ${m}`)
+  if (missing.length > 15) console.log(`  ...i ${missing.length - 15} więcej`)
+  console.log(`Podpowiedź: node scripts/generate-thumbnails.mjs --missing-only`)
+}
+
+if (DRY) {
+  console.log('\n--dry: plik nie zapisany')
+} else {
+  writeFileSync(OUT, xml, 'utf8')
+  console.log(`\nZapisano ${OUT.slice(ROOT.length)} (${(Buffer.byteLength(xml) / 1024).toFixed(0)} kB)`)
+}

--- a/utils/thumbs.js
+++ b/utils/thumbs.js
@@ -4,3 +4,14 @@ export const svgPreview = (url, kind = 'thumb') =>
   typeof url === 'string' && url.endsWith('.svg') && !url.startsWith('/vectors/')
     ? url.replace(/\.svg$/, `-${kind}.webp`)
     : url
+
+// Kandydaci do `srcset` w galeriach: 400px + 800px.
+// Powód: 93% wyświetleń w Grafice Google przypada na strony kategorii, a te serwowały
+// wyłącznie miniatury 400px — za małe, żeby konkurować w wynikach graficznych (średnia
+// pozycja 33). Pliki 800px już istnieją dla wszystkich kolorowanek, więc wystarczy je
+// zadeklarować: przeglądarka wybiera wg `sizes` i DPR, crawler ma z czego wziąć większy plik.
+// Zwraca null dla URL-i, które nie są kolorowanką (fallbacki, ikony) — wtedy atrybut nie leci.
+export const svgPreviewSrcset = (url) =>
+  typeof url === 'string' && url.endsWith('.svg') && !url.startsWith('/vectors/')
+    ? `${svgPreview(url, 'thumb')} 400w, ${svgPreview(url, 'view')} 800w`
+    : null


### PR DESCRIPTION
## Skąd to się wzięło

Analiza GSC za ostatnie 3 miesiące (Sieć + Grafika osobno):

| | Wyświetlenia | Kliknięcia | CTR | Poz. |
|---|---|---|---|---|
| Sieć | 609 975 | 9 362 | 1,53% | 6,8 |
| **Grafika** | **603 019** | **3 526** | **0,59%** | **33,0** |

**Grafika to połowa widoczności serwisu, a oddawaliśmy ją niemal w całości** — 47% wyświetleń lądowało na pozycji 31+, tylko 12,9% w top 10. Przy zapytaniach obiektowych („lody kolorowanka", „konik kolorowanka") użytkownik wybiera z karuzeli grafik, więc pozycja 1 w niebieskich linkach dawała CTR 0,89%. Trzy przyczyny, wszystkie po naszej stronie.

## Co zmienione

**1. `srcset` 400/800 px w galeriach** (`utils/thumbs.js`, `GalleryItem.vue`, `VariantCard.vue`)

Kategorie serwowały wyłącznie miniatury 400 px, a to na nie przypada 93% wyświetleń w Grafice. Warianty 800 px istniały, ale tylko na liściach — scanonicalizowanych na kategorię. Pliki były już wygenerowane (4217 szt.), więc zero nowych assetów. Fallback na SVG dostał zerowanie `srcset`, inaczej przeglądarka ciągnęłaby nieistniejące WebP.

**2. Pełne renderowanie galerii kategorii** (`pages/[...slug].vue`)

W HTML-u były tylko kafelki wplecione w sekcje H2 (`sekcje × 4`) — reszta czekała na klik w „załaduj więcej", którego crawler nie klika. Kategoria z 84 kolorowankami pokazywała 28. `loadMore` usunięte wraz z martwą maszynerią (`visibleCount`, `STEP`, `BEZ_SEKCJI_START`).

Zmierzone przed wdrożeniem, na zbudowanych plikach:

| Strona | Kafelki | HTML surowy | HTML po gzipie |
|---|---|---|---|
| `zwierzeta/koty` | 28 → **84** | +53,1 kB | **+1,8 kB (+4,8%)** |
| `zwierzeta/koniki` | 36 → **87** | +49,5 kB | **+1,8 kB** |
| `pojazdy/traktory` | 28 → **63** | +34,7 kB | **+1,2 kB** |
| `fantasy/syrenki` | 28 → **48** | +19,7 kB | **+0,7 kB** |

Markup kafelków jest skrajnie powtarzalny, więc gzip zjada go niemal w całości. **Obrazki po stronie sieci bez zmian** — każdy `<img>` ma `loading="lazy"`, więc przeglądarka nie pobiera nic spoza ekranu. Doładowywanie powstało, gdy kafelek ciągnął pełny SVG do 9,6 MB; po przejściu na WebP w Etapie 2 straciło powód istnienia.

**3. Sitemapa obrazów** (`scripts/sitemap-images.mjs`)

76 kategorii, **4165 obrazków**. Wpięta w `pnpm build` przed `nuxt generate` i w `robots.txt`, plus skrót `pnpm sitemap:images`. Każdy plik weryfikowany na dysku przed wpisaniem — sitemapa zwracająca 404 szkodzi bardziej niż jej brak. Wynik gitignorowany, bo w całości wyliczalny z `content/`.

Świadomie pominięte: przekroje (`tagsFilter`) pokazują te same pliki co kategorie — obrazek ma mieć jeden dom. Emitujemy wyłącznie `<image:loc>`, bo `image:title`/`caption`/`license` są przez Google wycofane.

## Weryfikacja

- `pnpm build` zielony, 8787 tras, `check-build OK`
- `srcset` obecny w zbudowanym HTML-u kategorii, kandydaci 400w/800w
- `/zwierzeta/koty/`: 84 kafelki w HTML wobec 28 przed zmianą; tyle samo w sitemapie
- **Niezmierzone:** LCP, TBT, CLS — wymagają uruchomienia przeglądarki. Element LCP jest nad zgięciem i się nie zmienia, dodatkowe kafelki są poniżej; realna niewiadoma to hydracja ~56 dodatkowych komponentów.

## Do zrobienia ręcznie po deployu

Zgłosić `sitemap-images.xml` w GSC → Sitemapy. Wpis w `robots.txt` wystarczy do odkrycia, ale jawne zgłoszenie daje osobny raport pokrycia — czyli metrykę, na której ocenimy, czy to zadziałało. Efekt w GSC widoczny zwykle po 3–6 tygodniach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
