### PR TITLE
Strategia ekspansji: zmierzony baseline, wybor rynkow, realia sieci reklamowych

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,10 +2,18 @@
 
 > Utworzona 2026-07-23 na bazie audytu technicznego i biznesowego.
 > Wykonawca: Claude (krok po kroku, etapami). Decyzje strategiczne: Jakub.
+>
+> **Warstwa strategiczna: `docs/strategia-ekspansji.md`** (2026-08-13) — zmierzony baseline,
+> wybór rynków, realia sieci reklamowych, architektura wielorynkowa, kanały poza serwisem
+> (Etsy, KDP) i bramki decyzyjne. Ten plik jest kolejką wykonawczą; tamten mówi dlaczego.
 
 ## Stan wyjściowy (audyt 2026-07-23)
 
-- ~23k ruchu organicznego/mies. wg SEMrush (szacunek wizyt), realne liczby do zmierzenia w Etapie 0.
+- ~~~23k ruchu organicznego/mies. wg SEMrush~~ — **KOREKTA (2026-08-13): zmierzone ~8,4k wizyt
+  i ~20k odsłon/mies.** (Cloudflare, 21 dni). SEMrush zawyża ~2,7×, bo modeluje ruch z pozycji ×
+  rynkowy CTR, a nasz realny CTR to 1,53% przy pozycji 6,8. **Zasada: ufać zmianom w SEMrushu
+  (+48% ruchu, +8,7% fraz to sygnał realny), nie wartościom bezwzględnym.** Pełne dane
+  w `strategia-ekspansji.md` §1.
 - 79 landingów kategorii/podkategorii (jednostka SEO), 4116 podstron kolorowanek (leaf), 4173 SVG + 4168 PDF w `public/` (~1,2 GB).
 - Hosting: Netlify (transfer na wykupionym wyższym pakiecie — koszt do zbicia).
 - GSC podpięte, GTM (GTM-PMTV7XJ8) za zgodą Klaro. Brak reklam, brak przychodów.
@@ -31,12 +39,17 @@ Wykonawcze (Claude):
 - [x] Odporność builda na awarię WordPressa: `routes-from-content.js` przy padzie WP przepisuje trasy bloga z poprzedniego `prerender-routes.json` (przetestowane symulacją), a nowy `scripts/check-build.mjs` (wpięty w `pnpm build`) wywala deploy przy pustym blogu/kategorii/leafie — koniec cichych pustych deployów mimo `failOnError:false`. (2026-07-23)
 - [x] Cloudflare Web Analytics wpięte w `nuxt.config.ts` przez env `CF_ANALYTICS_TOKEN` (bez tokena w repo). **AKTYWOWANE i zweryfikowane** — beacon na produkcji, dane spływają do panelu CF. Poza Klaro celowo (pomiar bez cookies = bez zgody, 100% ruchu); wpis w polityce prywatności + klauzula transferu poza EOG w PR #127. Etap 0 (baseline 2–4 tyg.) tym samym wystartował. (2026-07-23)
 - [ ] Po deployu: tydzień obserwacji transferu Netlify → jeśli spadł zgodnie z planem (80–95%), rozważyć powrót na tańszy pakiet.
+- [x] **Grafika Google — trzy naprawy w PR #162 (2026-08-13).** GSC pokazał, że **Grafika to połowa widoczności serwisu** (603 tys. wyświetleń wobec 610 tys. w Sieci), ale przy średniej pozycji **33** i CTR 0,59%. Przyczyny i naprawy: (1) galerie serwowały tylko miniatury 400 px, a 93% wyświetleń w Grafice przypada na kategorie → `srcset` 400/800 px; (2) w HTML-u kategorii było tylko `sekcje H2 × 4` kafelków, reszta za przyciskiem „załaduj więcej", którego crawler nie klika — kategoria z 84 kolorowankami pokazywała 28 → pełne renderowanie, `loadMore` usunięte (**koszt zmierzony: +1,8 kB po gzipie**, obrazki bez zmian dzięki `loading="lazy"`); (3) brak sitemapy obrazów → `scripts/sitemap-images.mjs`, 76 kategorii / 4165 obrazków, wpięta w `pnpm build` i `robots.txt`. Szacowany zapas: **2,5–3× ruchu bez nowych stron** — potwierdzony niezależnie rozjazdem SEMrush ↔ GSC.
+- [ ] **Zgłosić `sitemap-images.xml` w GSC → Sitemapy.** Wpis w `robots.txt` wystarczy do odkrycia, ale jawne zgłoszenie daje osobny raport pokrycia — to jest metryka, na której ocenimy efekt PR #162. **Odczyt ~15 września 2026.**
+- [ ] **Aplikować do Journey by Mediavine** — próg to **1 000 sesji**, mamy ~8 400. Nawet odmowa jest wartościowa: powie, jak sieci reklamowe traktują ruch spoza Tier 1, zanim zbudujemy 7 domen wokół założenia o RPM.
+- [ ] **Wystawić pakiet „Kim chcę zostać?" na Etsy** — najtańszy test jedynego nieprzetestowanego założenia całego modelu (czy ktokolwiek kupi). Etsy jest deemed supplier dla unijnego VAT-u przy produktach cyfrowych, więc OSS odpada z pierwszego podejścia. Odpowiedź w miesiąc.
+- [ ] Drobiazg z builda: **`/polityka-prywatnosci/regulamin` zwraca 404**, linkowane z `/polityka-prywatnosci/`. Zepsuty względny link na stronie prawnej; `failOnError: false` przepuszcza to po cichu.
 - [ ] **Newsletter + lead magnet „paczka 10 kolorowanek za maila" — wyciągnięte z Etapu 7 na teraz (decyzja Jakuba 2026-08-11).** Uzasadnienie: lista mailowa to jedyny kanał dotarcia niezależny od algorytmu Google i Pinteresta. Kroki: konfiguracja MailerLite (darmowy próg), formularz zapisu na leafach i po pobraniu PDF, automat powitalny wysyłający paczkę. **Warunek licencyjny — paczkę składać wyłącznie z grafik własnych (Recraft), nigdy z Freepika:** spakowanie 10 plików do pobrania to redystrybucja „as is", której standardowa licencja Freepika zabrania (zob. decyzja strategiczna nr 2 i nierozstrzygnięty punkt weryfikacji licencji wyżej). Nadają się tylko kategorie już podmienione w ramach migracji. Poczta domenowa gotowa: MX + DKIM działają, `include:_spf.mlsend.com` siedzi w SPF.
   - [x] **Integracja techniczna przetestowana end-to-end (2026-08-11).** Konto MailerLite (założone 26.02) miało już wszystko: `MAILERLITE_API_KEY` i `MAILERLITE_GROUP_ID` w Netlify, grupa „Newsletter Kolorowanki" (id 180499754188277517), domena zweryfikowana z DKIM `litesrv._domainkey`. Włączony **Double opt-in for API and integrations** (osobny przełącznik od formularzowego — bez niego zapisy przez API omijają potwierdzenie) i **Default sender** `team@twoja-kolorowanka.pl` (Account settings → Default settings; bez niego mail potwierdzający w ogóle nie wychodzi). Test przez `netlify functions:serve`: HTTP 200, subskrybent jako `unconfirmed`, mail potwierdzający dostarczony i podpisany DKIM-em domeny. Copy `NewsletterSection.vue` przepisane pod paczkę, komponent odkomentowany w `pages/index.vue` i `layouts/blog.vue`.
   - [x] **Paczka gotowa i na produkcji (2026-08-12).** Pakiet „Kim chcę zostać?" — 50 kolorowanek o zawodach z 26 zawodów, wygenerowanych Recraftem (whimsy, $0.04/szt.) i zwektoryzowanych ($0.01/szt.). Plik: `public/pakiet/kim-chce-zostac-k7m2x9.pdf` (51 stron z okładką, 1,05 MB), składany przez `scripts/zloz-pakiet.mjs`. Na produkcji odpowiada 200 z nagłówkiem `X-Robots-Tag: noindex, nofollow`. Materiał źródłowy i `_wybor.txt` w `lineart-work/pakiet-zawody/`.
   - [ ] **Dostarczalność przed pierwszą większą wysyłką:** test na mail-tester.com (punktacja 0–10 + lista zarzutów), rejestracja domeny w Google Postmaster Tools (reputacja nadawcy na danych z Gmaila), sprawdzenie czy MailerLite generuje niepustą wersję plain text. Unikać słowa „darmowy" w TEMACIE (w treści strony bezpieczne). Po miesiącu raportów DMARC podnieść `p=none` → `p=quarantine`. Rozważyć podmianę linku w mailu z bezpośredniego `.pdf` na stronę `/pakiet/` z przyciskiem — lepsza reputacja linku, kontrola nad zawartością bez ruszania maila, ruch wraca na serwis.
   - [x] **Popup/modal z pakietem — wdrożony 2026-08-12** (`components/NewsletterPopup.vue`, wpięty w `layouts/default.vue`). Desktop = modal z przyciemnieniem, mobile = dolny arkusz do 45vh **bez przyciemnienia** — zasłonięcie treści na telefonie to sygnał natrętnego interstitiala, za który Google obniża pozycje, a serwis żyje z organika. **Nie zamieniać na fullscreen.** Wyzwalacz: 30 s albo 50% scrolla. `localStorage` (`tk_newsletter_popup`) rozróżnia zamknięcie (cisza 30 dni) od zapisu (cisza na zawsze). Wykluczone: `/koloruj/` i cztery strony prawne. Nie ma go na blogu — ma osobny layout i własną sekcję newslettera nad stopką.
-  - [ ] **Zostaje automatyzacja w MailerLite** („gdy subskrybent dołącza do grupy Newsletter Kolorowanki" → mail z linkiem do paczki). Dopóki jej nie ma, formularz obiecuje coś, czego nikt nie dostanie. Automations są w darmowym planie.
+  - [x] **Automatyzacja w MailerLite działa (2026-08-12)** — „gdy subskrybent dołącza do grupy Newsletter Kolorowanki" → mail z linkiem do paczki. Przetestowane na produkcji w obie strony, pierwszy prawdziwy zapis przeszedł całą ścieżkę. **Lead magnet jest tym samym kompletny i działa end-to-end: formularz → double opt-in → paczka.**
   - [ ] Do regulaminu (sekcja V): punkt o paczce za zapis i zasadach korzystania z plików — dziś regulamin opisuje newsletter jako usługę bez świadczenia rzeczowego.
   - [ ] Dług: treść *Confirmation email* i *Confirmation thank you page* jest po angielsku — edycja wymaga płatnego planu. Double opt-in **nie jest wymogiem prawnym w PL**, narzuca go własny regulamin (sekcja V pkt 4b), więc alternatywą dla opłaty jest przeredagowanie tego punktu.
 
@@ -82,6 +95,14 @@ Zasada: pełny SVG pobiera się TYLKO w `/koloruj/` (edytor). Wszędzie indziej 
 
 ## Etap 3 — Start monetyzacji
 
+> **KOREKTA KOLEJNOŚCI (2026-08-13).** Baseline z Etapu 0 jest zebrany i mówi, że **Etap 3 stoi
+> w tym pliku za wcześnie**. Przy ~20 tys. odsłon AdSense to 40–120 zł/mies., a nie 100–350 jak
+> szacowano. Serwis jest przed monetyzacją, nie w niej. Dźwignie wg zwrotu:
+> **(1) odsłony na sesję** — 2,38 to dno przedziału, ekran po pobraniu podnosi każdy przyszły
+> strumień naraz; **(2) Etap 4** — każdy landing wart ~60 wizyt/mies., materiał już jest;
+> **(3) Etap 6** — polski RPM ustawia niski sufit niezależnie od ruchu.
+> Reklamy włączać po tych trzech, nie przed. Uzasadnienie: `strategia-ekspansji.md` §7.
+
 - [ ] Klaro: dodać Google Consent Mode v2 (wymóg reklam w EOG). **Zaimplementowane w PR #129 — czeka na review Jakuba** (domyślnie wszystko denied, zgody sterują sygnałami; kategoria Reklamowe + usługa AdSense w banerze gotowe na Etap 3). (2026-07-23)
 - [ ] Wniosek do **AdSense** (po czystce brandów z Etapu 1) — start i punkt odniesienia. Alternatywa/test B: Ezoic (brak progu, zwykle wyższy RPM). **DECYZJA (2026-07-23): odroczony do zebrania baseline'u** — przy szacowanych 40–60k odsłon/mies. i RPM 2–6 zł (PL, nisza dziecięca, made-for-kids, część ruchu bez zgody) wyszłoby ~100–350 zł/mies. Ocena po ~miesiącu danych z Cloudflare; wtedy też planowanie placementów na realnych top stronach. Pamiętać: review AdSense trwa 2–4 tyg., doliczyć do timeline'u.
 - [ ] Placement: strony kategorii (in-content między sekcjami galerii) + leafy (pod przyciskami, nad „Podobnymi"). NIGDY w `/koloruj/` (UX dzieci + i tak noindex).
@@ -103,10 +124,22 @@ W niszy printables Pinterest bywa większy niż Google. Mechanika: pin = pionowa
 
 - [ ] Konto firmowe Pinterest + weryfikacja domeny + włączenie Rich Pins (czytają OG tagi — już je mamy). **W TOKU (2026-07-23): Jakub zakłada konto**; weryfikacja metodą „Add HTML tag" — tag wkleja Claude'owi, trafia do `nuxt.config.ts`. Decyzja: startujemy teraz, żeby konto wygrzało się przed pikiem Q4 (publikacja sezonowa od września).
 - [x] Skrypt `scripts/generate-pins.mjs`: miniatura kolorowanki → grafika pinu 2:3 (1000×1500, biała ramka, pasek z tytułem i domeną) — masowo z istniejących WebP. Flagi `--limit`/`--only`, wyjście do `pins-output/` (gitignore). Masowe uruchomienie po założeniu konta. (PR #131, 2026-07-23)
-- [ ] Automatyzacja publikacji: **Pinterest API v5** (oficjalne, darmowe) — skrypt planujący 3–5 pinów/dzień z kolejki; boardy per kategoria + boardy sezonowe. Alternatywa bez kodu: Buffer/Tailwind (płatne).
+- [x] Automatyzacja publikacji: **Pinterest API v5 — kod gotowy.** `scripts/pinterest/publish.mjs` (kolejka ze wszystkich leafów minus `data/pinterest-state.json`, wybór round-robin po kategoriach dla dziennej różnorodności, boardy z `data/pinterest-boards.json` z automatycznym tworzeniem brakujących, grafika komponowana in-memory przez `image_base64` — zero hostingu), `auth.mjs` do tokenu, `lib.mjs` wspólne z `generate-pins.mjs`. Obsługuje `--count`, `--dry-run` i env `PINTEREST_APP_ID/SECRET/REFRESH_TOKEN` pod CI.
+- [ ] **Zostaje uruchomienie:** konto firmowe + token + wpięcie w cron GitHub Actions. Nic do napisania.
 - [ ] Start: 5 boardów (zwierzęta, mandale/antystres, sezonowe, edukacyjne, pojazdy), potem rozbudowa wg statystyk.
 
 ## Etap 6 — Ekspansja językowa (największa dźwignia przychodu)
+
+> **AKTUALIZACJA 2026-08-13 — decyzje podjęte, szczegóły w `strategia-ekspansji.md` §4–5.**
+> Kolejność rynków: **NL → DE → IT (produktowo) → SE**, dopiero potem EN. NL pierwszy, bo
+> CPC $3,59 przy KD 20 (DE: $2,24 przy KD 50) — przy Authority Score 12 tam można zdominować
+> rynek, w DE tylko powalczyć. **FR i ES to pułapki objętościowe** (FR: KD 63 i CPC $0,49;
+> ES: CPC $0,19, wolumen głównie LatAm). **Architektura: osobne domeny ccTLD** — argument za
+> pulą upadł, bo Raptive jest zamknięty geograficznie (wymaga 40–50% ruchu Tier 1) niezależnie
+> od skali. Mediavine przeszedł na próg przychodowy ($5 tys./rok) i jest osiągalny.
+> **Dla rynków europejskich produkty biją reklamy** — na nowym rynku najpierw sklep.
+> Warstwa lokalna (Sinterklaas, Lucia, 17. mai) to najtańsza przewaga i zarazem ochrona przed
+> oceną „skalowane treści".
 
 SVG/PDF są językowo neutralne — koszt wejścia to tłumaczenie ~79 landingów + szablonowe meta leafów. Wysokie RPM-y sieci premium (Journey/Raptive $13–40+) dotyczą ruchu EN/US — polska strona ich nie zobaczy; wersja EN tak.
 
@@ -142,7 +175,8 @@ Frazy do weryfikacji wolumenów (SEMrush, baza per kraj):
 - [ ] **Pomysły Jakuba na produkty tematyczne (2026-07-23):** poczet królów Polski (podstawa programowa kl. 4–5 → kupują też nauczyciele, popyt cykliczny), księżniczki z historii Polski, mity słowiańskie (nisza bez konkurencji, wersja EN „Slavic mythology" = rynek globalny). Tematyczność broni ceny 29–49 zł vs 19 zł za generyk. Piki sprzedażowe: wrzesień (rok szkolny), 11 XI, Dzień Flagi — publikacja 2 mies. wcześniej. Do weryfikacji w SEMrush: „kolorowanki historia polski", „kolorowanki mity słowiańskie", „poczet królów dla dzieci". Realistyczny model konwersji: 0,1–0,5% ruchu → przy dzisiejszym ruchu 500–1500 zł/mies., po roku 2–7 tys., dojrzale 7–18 tys. zł/mies. (produkty + osobno reklamy).
 - [ ] Generator kolorowanek z imieniem dziecka (sekcje `generator-cta` już istnieją w contencie) — produkt premium.
 - [ ] Afiliacja: recenzje kredek/markerów na blogu + webePartners/Awin (Empik, Allegro).
-- [ ] **WhitePress** (artykuły sponsorowane na blogu): rejestracja portalu, wycena startowa ~300–800 zł/artykuł. Zasady bezpieczeństwa: max 2–4 artykuły/mies., oznaczanie „artykuł sponsorowany" (wymóg UOKiK), tematyka zbliżona do niszy (dzieci/rodzina/edukacja), nie pozwolić żeby sponsorowane zdominowały blog — nadmiar płatnych linków dofollow to ryzyko kary od Google.
+- [ ] **Amazon KDP** — druk bez inwentarza z tej samej kolekcji co paczka cyfrowa. Przewaga: SVG daje dowolny format bez straty, a `scripts/zloz-pakiet.mjs` (pdfkit + svg-to-pdfkit) już istnieje — wariant pod specyfikację KDP (spady, margines na oprawę zależny od liczby stron, 300 DPI) to modyfikacja, nie nowy projekt. Mocniejszy argument: **gra wielorynkowa bez budowania stron** — amazon.de/.fr/.it/.es/.nl/.se/.pl istnieją, a kolorowanka jest produktem prawie bezjęzykowym (tłumaczy się tytuł, opis, słowa kluczowe). Ruch przynosi Amazon. Jednostkowo ~€2,50–2,80/egz. przy €7,99 i ~55 stronach; problem jest w odkrywalności, nie w marży — rynek przeorany, mediana tytułu sprzedaje się blisko zera, to biznes portfelowy. **Obowiązek: KDP wymaga ujawnienia treści generowanych AI** (obowiązkowe pole, obejmuje wprost kolorowanki; nie jest pokazywane klientom, ale nieujawnienie grozi blokadą konta). Kolejność: **po teście na Etsy**, bo oba kanały testują to samo założenie, a Etsy odpowiada szybciej i bez okładki, formatowania i reklam.
+- [ ] **WhitePress** (artykuły sponsorowane na blogu): rejestracja portalu. **KOREKTA WYCENY (2026-08-13):** startowe ~300–800 zł/artykuł było optymistyczne — przy **Authority Score 12 i 154 domenach odsyłających** kupujący wyceniają nisko, a nisza jest wąska tematycznie. Realnie **500–1500 zł/mies. przy 2–4 publikacjach**, czyli dodatek, nie filar. Dodatkowo **blog ma 49 postów i 431 wyświetleń w GSC za 3 miesiące** — nie ma własnego autorytetu organicznego, jest czystym nośnikiem linków, a to profil, który się wyłapuje. Zasady bezpieczeństwa: max 2–4 artykuły/mies., **`rel="sponsored"` na wszystkich linkach wychodzących** (roadmapa wspominała o ryzyku dofollow, ale nie nazywała mechaniki — tak, cena wtedy spada i to jest ta cena), oznaczanie „artykuł sponsorowany" (wymóg UOKiK), wyłącznie tematyka dziecięco-rodzicielsko-edukacyjna bez wycieczek w finanse i suplementy. **Model wolumenowy (20–30 art./mies. po 50 zł) jest tu wykluczony** — działa na portalach, gdzie portal JEST produktem; tutaj kara od Google zabija AdSense, sprzedaż paczek i ekspansję naraz, żeby uratować najmniejszy strumień.
 
 ## Etap 8 — Własne narzędzia monitorujące (mini-stack zamiast SEMrusha)
 

--- a/docs/strategia-ekspansji.md
+++ b/docs/strategia-ekspansji.md
@@ -1,0 +1,344 @@
+# Strategia ekspansji i monetyzacji
+
+> Spisana 2026-08-13 po sesji analitycznej na realnych danych (Cloudflare, GSC, SEMrush)
+> i researchu sieci reklamowych. Warstwa strategiczna **nad** `ROADMAP.md` — tamten plik
+> jest kolejką wykonawczą, ten opisuje kierunek i uzasadnienie decyzji.
+>
+> **Zasada czytania:** wszędzie rozdzielone jest to, co **zmierzone**, od tego, co **szacowane**.
+> Szacunki są moje i mają szerokie widełki. Nie planuj na nich budżetu bez weryfikacji.
+
+---
+
+## 1. Stan faktyczny — zmierzony 2026-08-13
+
+Zastępuje szacunki z audytu 2026-07-23, które były zawyżone ~2,7×.
+
+| Metryka | Wartość | Źródło |
+|---|---|---|
+| Wizyty | **~8 400/mies.** | Cloudflare, 21 dni (5,9k) → ekstrapolacja |
+| Odsłony | ~20 000/mies. | Cloudflare (14,07k / 21 dni) |
+| Odsłony na wizytę | **2,38** | dno przedziału dla printables (dobre serwisy: 4–8) |
+| Authority Score | **12** | SEMrush |
+| Domeny odsyłające | **154** | SEMrush (4,7 tys. linków = profil sitewide, nie redakcyjny) |
+| Frazy organiczne | 2,8 tys. (+8,7%) | SEMrush |
+
+Doliczyć 10–25% do liczb z Cloudflare — beacon `cloudflareinsights.com` jest na części list blokujących.
+
+### Google Search Console, 3 miesiące
+
+| | Wyświetlenia | Kliknięcia | CTR | Poz. |
+|---|---|---|---|---|
+| Sieć | 609 975 | 9 362 | 1,53% | 6,8 |
+| **Grafika** | **603 019** | **3 526** | **0,59%** | **33,0** |
+| Razem | **1 213 000** | 12 888 | 1,06% | — |
+
+**Grafika to połowa widoczności serwisu.** 47% jej wyświetleń lądowało na pozycji 31+, tylko 12,9% w top 10.
+
+### Rozkład ruchu po typach stron (Sieć)
+
+- **kategorie: 79% kliknięć** (94 strony, 490 tys. wyświetleń)
+- strona główna: 20% (108 tys. wyświetleń, CTR 1,76%)
+- leafy: 0,9% (720 stron, CTR 0,38%) — zgodnie z projektem, są poza sitemapą
+- przekroje (Etap 4): 13 stron, 19 kliknięć — w indeksie od 24 lipca, za wcześnie na ocenę
+- **blog: 49 postów → 431 wyświetleń, 11 kliknięć** — praktycznie nie istnieje w Google
+
+### Wzorzec CTR — kluczowa obserwacja
+
+Zapytania dzielą się na dwa typy i zachowują skrajnie różnie:
+
+- **obiektowe** („lody kolorowanka", „konik kolorowanka") — CTR **0,1–1%** mimo pozycji 1–5,
+  bo karuzela grafik przechwytuje uwagę, zanim użytkownik zejdzie do niebieskich linków
+- **kolekcyjne** („kolorowanki do druku za darmo") — CTR **3%+**
+
+Skrajny przykład: `/dla-doroslych/po-numerach/` ma CTR **5,92%** przy pozycji 5,3 — bo przy tym
+zapytaniu szuka się systemu, nie obrazka. `/zwierzeta/koniki/` ma **0,43%** przy pozycji 7.
+
+### Co z tego wynika: SEMrush i GSC mówią to samo
+
+SEMrush szacuje ruch na **24,9 tys./mies.** — czyli tyle, ile obecne pozycje **powinny** dawać przy
+rynkowym CTR. Realnie masz ~4,3 tys. kliknięć z Google. **Masz ~3× więcej widoczności niż ruchu.**
+
+**Zasada na przyszłość: ufaj zmianom w SEMrushu, nie wartościom bezwzględnym.** `+48%` ruchu
+i `+8,7%` fraz to sygnał realny. Liczba 24,9 tys. nie nadaje się do planowania przychodu.
+
+---
+
+## 2. Co zostało naprawione (PR #162, 2026-08-13)
+
+Trzy przyczyny słabego wyniku w Grafice, wszystkie po naszej stronie:
+
+1. **Galerie serwowały tylko miniatury 400 px.** 93% wyświetleń w Grafice przypada na kategorie,
+   a warianty 800 px leżały wyłącznie na liściach — scanonicalizowanych na kategorię.
+   → `srcset` 400/800 px w `GalleryItem` i `VariantCard`.
+2. **W HTML-u kategorii było tylko `liczba sekcji H2 × 4` kafelków.** Reszta czekała na klik
+   w „załaduj więcej", którego crawler nie klika — kategoria z 84 kolorowankami pokazywała 28.
+   → pełne renderowanie, `loadMore` usunięte. Koszt zmierzony: **+1,8 kB po gzipie** (+4,8%)
+   przy potrojeniu liczby kafelków. Obrazki bez zmian dzięki `loading="lazy"`.
+3. **Brak sitemapy obrazów.** → `scripts/sitemap-images.mjs`, 76 kategorii, **4165 obrazków**.
+
+**Efekt do odczytu w GSC od ~połowy września 2026.** Metryka: raport pokrycia dla
+`sitemap-images.xml` (zgłosić ręcznie w GSC) oraz średnia pozycja w Grafice.
+
+Szacowany zapas: **2,5–3× ruchu bez nowych stron i bez nowych pozycji** — potwierdzony
+niezależnie przez rozjazd SEMrush ↔ GSC.
+
+---
+
+## 3. Monetyzacja — twarde ustalenia z researchu
+
+### Sieci reklamowe premium są zamknięte dla ruchu europejskiego
+
+| Sieć | Próg | Wymóg geograficzny | Dostępne? |
+|---|---|---|---|
+| **Raptive** | 25 tys. odsłon | **50% Tier 1** (US/UK/CA/AU/NZ), 40% powyżej 100 tys. | ❌ nie dla ruchu z UE |
+| **Mediavine** | **$5 000/rok przychodu z reklam** | preferuje Tier 1, DE case-by-case | ⚠️ osiągalne |
+| **Journey by Mediavine** | **1 000 sesji** | preferuje Tier 1 | ✅ aplikować teraz |
+| **Setupad** | 100 tys. wizyt | brak | ✅ cel docelowy (firma z Łotwy, CMP w cenie) |
+| **Snigel** | 100 tys. odsłon | tylko 20% Tier 1 | ⚠️ przy wersji EN |
+| Ezoic / AdSense | brak | brak | ✅ baza odniesienia |
+
+**To jest najważniejsze ustalenie tej sesji.** Raptive gatuje **geografią** — szwedzka czy
+holenderska domena nie spełni tego warunku niezależnie od skali. Mediavine przeszedł na próg
+**przychodowy**, co dla europejskiego wydawcy jest odpowiadalne („czy Twój ruch zarabia"
+zamiast „skąd jest Twój ruch").
+
+Serwisy siostrzane: Raptive przyjmuje kolejny serwis istniejącego wydawcy przy 25 tys. odsłon;
+Mediavine **skasował** nieoficjalną praktykę przyjmowania siostrzanych poniżej progu.
+
+### Szacowany RPM dla ruchu europejskiego: $2–5
+
+Twarde dane: AdSense RPM dla czołowych rynków anglojęzycznych to **$4,59–6,15**. Średnie CPC
+krajowe: US $0,61, UK $0,48, FI $0,45, SE $0,31, DK $0,28, NO $0,26, DE $0,22, IT $0,13.
+
+**Uwaga — to przeczy folklorowi o wysokich stawkach skandynawskich.** Norwegia i Szwecja mają
+CPC na poziomie połowy amerykańskiego, nie powyżej.
+
+Kontrapunkt: CPC dla samej frazy „kleurplaten" (NL) to **$3,59**, czyli wielokrotnie powyżej
+średniej krajowej. Jedna z tych liczb nie mówi całej prawdy. **Rozstrzygnie dopiero realny ruch.**
+
+### Wniosek: dla rynków europejskich produkty biją reklamy
+
+Sprzedaż PDF nie zna pojęcia Tier 1, nie ma progu i nie wymaga aplikacji. Szwedzki rodzic płaci
+tyle samo co polski — a przy wyższej sile nabywczej często więcej.
+
+**Na każdym nowym rynku: najpierw sklep, potem reklamy.** Reklamy finansują hosting; produkty
+są biznesem.
+
+---
+
+## 4. Wybór rynków
+
+| Rynek | Uniwersum fraz | CPC | KD | Ocena |
+|---|---|---|---|---|
+| **NL** kleurplaat/-en | 1,9 mln | **$3,59** | **20** | **pierwszy** |
+| **DE** ausmalbilder | **4,7 mln** | $2,24 | 50 | drugi — największy sufit |
+| IT disegni da colorare | 1,5 mln | $0,36 | **25** | rynek **produktowy**, nie reklamowy |
+| SE målarbilder | 254 tys. | $0,50 | 17 | tani dodatek, gdy koszt języka spadnie |
+| FR coloriage | **5,9 mln** | $0,49 | **63** | ❌ pułapka: najtrudniej i słabo płaci |
+| ES dibujos para colorear | 1,5 mln | **$0,19** | 37 | ❌ pułapka: wolumen LatAm, gęstość reklam 0,02 |
+| NO fargelegging | **26 tys.** | $0,43 | 12 | ❌ za mały samodzielnie |
+
+**Zasada: mały rynek bez konkurencji przy przyzwoitym CPC bije duży rynek z rzezią.**
+Przy Authority Score 12 w NL można realnie zdominować rynek; w DE można powalczyć; w EN
+nie zaczyna się walki (supercoloring, justcolor, crayola + setki farm AI).
+
+**Kolejność: NL → DE → IT (produktowo) → SE → dopiero EN.**
+
+### Warstwa lokalna to najtańsza przewaga konkurencyjna
+
+Ok. 90% biblioteki przenosi się 1:1 (zwierzęta, pojazdy, kwiaty, jednorożce). Święta — nie:
+
+- **NL:** Sinterklaas (5 XII) — osobna, duża fraza sezonowa, nie Boże Narodzenie
+- **NO:** 17. mai — poza radarem serwisów międzynarodowych
+- **SE:** Lucia (13 XII), midsommar
+- **CZ/SK:** własny kalendarz
+
+Serwisy globalne tego nie mają, bo tłumaczą jeden zestaw. Plan: **20–40 kolorowanek per rynek
+pod lokalne święta.** To jednocześnie chroni przed oceną „skalowane treści" — siedem serwisów
+z mechanicznie przetłumaczoną tą samą biblioteką to profil, który systemy antyspamowe rozpoznają.
+
+**Uwaga wspólna:** w czołówce każdego rynku siedzą frazy markowe (pokemon, stitch), z których
+rezygnujemy decyzją strategiczną nr 2. **DE ma najczystszy profil generyczny** — „einhorn
+ausmalbild" 27,1 tys., „ausmalbilder weihnachten" 18,1 tys., „ausmalbilder zum ausdrucken"
+33,1 tys. To częściowo odrabia jego wyższe KD.
+
+---
+
+## 5. Architektura wielorynkowa
+
+### Decyzja: osobne domeny ccTLD (`.nl`, `.de`, `.se`…)
+
+Pierwotnie argumentowałem za pulą (podkatalogi na jednej domenie), bo przekracza progi sieci
+premium. **Ten argument upadł** — Raptive jest geograficznie zamknięty niezależnie od skali,
+więc pula nie kupuje dostępu do premium.
+
+Zostają zalety ccTLD:
+- **Google wycofał ustawianie kraju w Search Console** — dla `.com` nie ma już ręcznego
+  przełącznika, przy ccTLD sygnał jest jednoznaczny
+- zaufanie i CTR w wynikach — istotne przy serwisie bez rozpoznawalnej marki
+- brak zależności od hreflanga (przy 7 rynkach to kilkadziesiąt wzajemnych deklaracji,
+  jedna z najczęściej psutych rzeczy w SEO)
+
+**Do sprawdzenia przed planowaniem:** `.no` historycznie wymagał podmiotu zarejestrowanego
+w Norwegii. `.se`, `.fi`, `.cz`, `.is` są otwarte. `.dk` zweryfikować osobno.
+
+**Uwaga:** przy językach jeden-do-jednego z krajem (SV, DA, NO, FI, CS, SK) sam język jest
+sygnałem geograficznym i ccTLD daje głównie zaufanie/CTR. Targetowanie krajowe naprawdę waży
+tam, gdzie jeden język obsługuje kilka rynków: **NL vs BE**, DE/AT/CH, PT vs BR.
+
+### Mechanika buildów
+
+Dwie osobne rzeczy, które łatwo pomylić:
+
+**Co wchodzi do builda rynku — rozstrzyga katalog.** `content-sv/svenska-kungar/` istnieje tylko
+w szwedzkim drzewie. Żółwie istnieją w siedmiu drzewach jako siedem przetłumaczonych plików
+wskazujących na **te same** SVG. Flaga nie jest potrzebna — obecność w drzewie jest flagą.
+
+**Które rynki przebudować po pushu — wymaga logiki.** Netlify ma to natywnie:
+
+```toml
+[build]
+  ignore = "node scripts/should-build.mjs"   # exit 0 = pomiń, exit 1 = buduj
+```
+
+Skrypt czyta `CACHED_COMMIT_REF`/`COMMIT_REF` i `SITE_LOCALE`:
+
+| Zmiana w repo | Przebudowa |
+|---|---|
+| `content-<locale>/**` | tylko ten rynek |
+| `components/`, `pages/`, `layouts/`, `utils/`, `nuxt.config.ts`, `scripts/` | wszystkie |
+| `public/**` | wszystkie (miniatury + sitemapa obrazów) |
+
+Bez tego każdy commit przebudowuje 7 serwisów po ~5 minut. **GitHub Actions zostaje do croników
+Etapu 8** (health-check, monitor indeksu, pull z GSC), nie do deployów.
+
+### Assety: duplikowane per domena — świadomie
+
+Kusi hostowanie grafik z jednego miejsca. **Nie robić tego:** obrazki hostowane na innej domenie
+indeksują się w Grafice pod **tamtą** domeną. Straciłoby to cały zysk z sekcji 2 i rozmyło sygnał
+lokalny. Koszt duplikacji (~1,2 GB × N) jest akceptowalny; `generate-thumbnails --missing-only`
+plus cache Netlify sprawiają, że po pierwszym buildzie nie boli.
+
+---
+
+## 6. Kanały poza własnymi serwisami
+
+Kluczowa obserwacja: **odwiedzający Twój serwis przyszedł po darmowe.** To najtrudniejsza
+publiczność do konwersji — już dostał to, po co przyszedł. Na Etsy i Amazonie ludzie przychodzą
+**kupować**. To inne audytorium, nie ten sam lejek.
+
+### Etsy — pierwszy test popytu
+
+- listing $0,20, nie wymaga ruchu ani zmian w serwisie
+- **Etsy jest deemed supplier dla unijnego VAT-u przy produktach cyfrowych** — rozlicza go
+  za Ciebie, więc OSS odpada z pierwszego podejścia
+- materiał gotowy: pakiet „Kim chcę zostać?" (50 stron)
+- odpowiedź w miesiąc
+
+### Amazon KDP — druk bez inwentarza
+
+Przewaga: **SVG = dowolny format bez straty jakości**, a `scripts/zloz-pakiet.mjs` (pdfkit +
+svg-to-pdfkit) już istnieje — wariant pod specyfikację KDP to modyfikacja, nie nowy projekt.
+
+Mocniejszy argument: **gra wielorynkowa bez budowania stron.** Amazon.de/.fr/.it/.es/.nl/.se/.pl
+istnieją, a kolorowanka jest produktem prawie bezjęzykowym — tłumaczy się tytuł, opis i słowa
+kluczowe. **Ruch przynosi Amazon.** To hedge wobec całej strategii SEO. Cena: nie budujesz
+relacji z klientem — to przychód, nie aktywo.
+
+Jednostkowo: ~55 stron, €7,99 na amazon.de → 60% royalty minus druk (~€2,00–2,50) =
+**~€2,50–2,80/egz.** Problem nie w marży, tylko w odkrywalności — rynek jest przeorany,
+mediana tytułu sprzedaje się blisko zera. To biznes portfelowy: 20–40 tytułów, kilka ciągnie resztę.
+
+**Obowiązek: KDP wymaga ujawnienia treści generowanych AI** — obowiązkowe pole w formularzu,
+obejmuje wprost kolorowanki. Nie jest pokazywane klientom i nie wpływa na ranking, ale
+nieujawnienie grozi zablokowaniem konta. (Unijny AI Act tego **nie** wymaga — art. 50 dotyczy
+deep fake'ów; kolorowanka nim nie jest. Prawo nie, platforma tak.)
+
+### Jedna kolekcja → cztery kanały
+
+Dobrze złożona kolekcja 50 kolorowanek to jednocześnie: lead magnet, paczka na Etsy, książka
+na KDP i płatny produkt na własnej stronie. **Iść w głąb jednej kolekcji, nie wszerz.**
+
+---
+
+## 7. Ekonomia — model i jego słabe punkty
+
+Założenie bazowe dla **dojrzałego** rynku: 8 000 wizyt/mies. ≈ 30 000 odsłon (przy 3,7 odsłony
+na wizytę po naprawie galerii).
+
+| Strumień | Założenie | Na rynek/mies. |
+|---|---|---|
+| Reklamy | 30 tys. odsłon × RPM $2–5 | €55–140 |
+| Produkty | 8 tys. wizyt × konw. 0,1–0,5% × €9 | €72–360 |
+| Lista mailowa | kampanie do ~500 zapisanych | €20–60 |
+| **Razem** | | **€150–560** (~650–2 400 zł) |
+
+| | Podłoga (same reklamy) | Z produktami |
+|---|---|---|
+| 7 rynków | 2 100–5 600 zł | 4 500–16 800 zł |
+| 10 rynków | 3 000–8 000 zł | 6 500–24 000 zł |
+
+**Podłoga jest przypadkiem dolnym** — ile zostaje, gdy produkty w ogóle nie wypalą. To scenariusz
+akceptowalny, i to jest główny argument za podjęciem ryzyka.
+
+### Trzy rzeczy, przez które to nie jest prognoza
+
+1. **Szacunki mnożone przez szacunki.** RPM $2–5 jest mój. Konwersja 0,1–0,5% pochodzi
+   z roadmapy i też jest zgadywana. „8 tys. wizyt na rynek" jest optymistyczne dla Norwegii
+   i pesymistyczne dla Holandii.
+2. **Nośne założenie nigdy nie było testowane: czy paczki PDF w ogóle się sprzedają.**
+   Przy konwersji 0,05% zamiast 0,3% kolumna produktów spada 6× i całość leci poniżej celu.
+3. **To jest stan dojrzały.** Każdy rynek potrzebuje 9–18 miesięcy, żeby tam dojść — choć
+   przy gotowej bibliotece, kodzie i playbooku to realnie 15–25% pracy włożonej w Polskę.
+
+### Prawdziwy sufit tej strategii: ogon utrzymaniowy
+
+**Kumuluje się:** biblioteka grafik, narzędzia, kolekcje produktowe, wiedza o konwersji.
+
+**Nie kumuluje się:** pozycje, linki, sezonowe treści lokalne, obsługa klienta, rozliczenia,
+strony prawne. To wraca co roku, per rynek.
+
+„Mały nakład" razy siedem to nie jest mały nakład. Dlatego **automaty z Etapu 8 przestają być
+gadżetem** — przy jednym serwisie monitoring to wygoda, przy siedmiu to warunek wykonalności
+obok JDG.
+
+---
+
+## 8. Bramki decyzyjne — kupujemy informację przed zobowiązaniem
+
+Nie ma dziś decyzji o dwóch latach. Są trzy tanie eksperymenty, każdy zabija albo potwierdza
+jedno nośne założenie:
+
+| # | Test | Koszt | Odpowiada na | Wynik |
+|---|---|---|---|---|
+| 1 | Naprawa Grafiki | **zrobione** (PR #162) | czy ruch da się odzyskać bez nowych treści | ~15 IX 2026 |
+| 2 | **Paczka na Etsy** | weekend | **czy ktokolwiek to kupi** | ~1 miesiąc |
+| 3 | Jeden rynek (NL) | 2–3 tygodnie | realny RPM i tempo indeksacji | ~1 kwartał |
+
+Cztery miesiące rozstrzygają większość niepewności z tego dokumentu.
+
+**Warunek wstępny przed replikacją na wiele domen:** wymiana biblioteki na własne grafiki musi
+być domknięta. Jeden nierozstrzygnięty problem licencyjny pomnożony przez siedem domen w pięciu
+krajach to inna kategoria sprawy niż ten sam problem na jednym serwisie.
+
+### Do zrobienia od razu
+
+- [ ] Zgłosić `sitemap-images.xml` w GSC → Sitemapy (osobny raport pokrycia = metryka dla testu 1)
+- [ ] Aplikować do **Journey by Mediavine** (próg 1 000 sesji, mamy 8 400) — nawet odmowa jest
+      wartościowa: powie, jak sieci traktują ruch spoza Tier 1, zanim zbudujemy 7 domen
+- [ ] Odezwać się do **Setupadu** o realny RPM dla ruchu PL/SE/NL w niszy dziecięcej —
+      to jedyna liczba, której brakuje całemu modelowi
+- [ ] Wystawić pakiet „Kim chcę zostać?" na Etsy
+- [ ] Konto serwisowe Google Cloud + Search Console API → monitor indeksu (Etap 8)
+- [ ] Sprawdzić wymogi rejestracyjne `.no` i `.dk`
+
+---
+
+## 9. Opcja, która też jest poprawna
+
+Można **wziąć małe i przestać inwestować**. Naprawiona Grafika + AdSense + okazjonalna
+publikacja to prawdopodobnie kilkaset złotych miesięcznie przy niewielkim nakładzie.
+
+To nie jest porażka — to projekt, który się zwrócił i zamienił w drobny, pasywny strumień.
+Ekspansja ma sens tylko wtedy, gdy jest chęć jej budowania. Jeśli po trzech testach okaże się,
+że to męczarnia bez sygnału, zatrzymanie się jest decyzją, a nie odpuszczeniem.


### PR DESCRIPTION
Nowy `docs/strategia-ekspansji.md` — warstwa strategiczna nad roadmapą, spisana po sesji analitycznej na realnych danych (Cloudflare, GSC Sieć + Grafika, SEMrush) i researchu sieci reklamowych.

**Najważniejsze ustalenia:**

- **Baseline był zawyżony 2,7×** — zmierzone ~8,4 tys. wizyt, nie 23 tys.
- **Grafika Google to połowa widoczności serwisu** i była oddawana niemal w całości (pozycja 33, CTR 0,59%). Naprawione w #162.
- **Sieci premium są zamknięte dla ruchu europejskiego** — Raptive wymaga 40–50% ruchu Tier 1 niezależnie od skali. To unieważnia argument za pulowaniem domen; osobne ccTLD zostają.
- **Dla rynków europejskich produkty biją reklamy** (~60% modelowego przychodu wobec ~28%).
- **Kolejność rynków: NL → DE → IT → SE**, dopiero potem EN. FR i ES to pułapki objętościowe.
- **Kolejność w roadmapie była odwrotna do danych** — Etap 3 stoi przed 4 i 6, a powinien po.

Model podany z podłogą (same reklamy) i sufitem (z produktami), z wyraźnym oznaczeniem, że nośne założenie — czy paczki PDF w ogóle się sprzedają — nigdy nie było testowane. Stąd trzy bramki decyzyjne zamiast zobowiązania na dwa lata.

**ROADMAP.md:** skorygowany baseline, korekta kolejności w Etapie 3, decyzje w Etapie 6, przecenione widełki WhitePressa i dopisany KDP w Etapie 7, Pinterest API oznaczony jako gotowy w kodzie, zadania z tego tygodnia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)